### PR TITLE
Lottiegreenwood/11003 add checks instrument in experiment dictionary

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -109,8 +109,13 @@ def run_list(request):
             'is_active' : instrument.is_active
         }
         
-        instrument_experiments = experiments[instrument_name] #add check here
+        if instrument_name not in experiments:
+            experiments[instrument_name] = []
+            
+        instrument_experiments = experiments[instrument_name] 
         reference_numbers = []
+        
+            
         for experiment in instrument_experiments:
             # Filter out calibration runs
             if experiment.isdigit():

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -136,7 +136,7 @@ def run_list(request):
                 if run.status == StatusUtils().get_processing():
                     experiment_processing_runs += 1
 
-            # Add exepriment stats to instrument
+            # Add experiment stats to instrument
             instrument_queued_runs += experiment_queued_runs
             instrument_processing_runs += experiment_processing_runs
             instrument_error_runs += experiment_error_runs


### PR DESCRIPTION
To test: Log onto autoreduction (​http://reduce.isis.cclrc.ac.uk/) with an account that has access to a particular instrument for autoreduction, but has no experiments available to view for that instrument. Check everything loads correctly.

http://trac.mantidproject.org/mantid/ticket/11003
