### PR TITLE
Rerunning autoreduction with a long description causes 500 error

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -114,6 +114,11 @@
         var validateText = function validateText(){
             validateNotEmpty.call(this);
         };
+		var validateDescriptionText = function validateDescriptionText(){
+            if($(this).val().length() > 100) {
+                errorMessages.push(getVarName('Re-run description must be less than 100 characters.')
+            }
+        };
         var validateNumber = function validateNumber(){
             validateNotEmpty.call(this);
             if(!isNumber($(this).val())){
@@ -174,6 +179,7 @@
         $form.find('[data-type="boolean"]').each(validateBoolean);
         $form.find('[data-type="list_number"]').each(validateListNumber);
         $form.find('[data-type="list_text"]').each(validateListText);
+		$form.find('[nodeValue="run_description').each(validateDescriptionText);
 
         if(!isValid){
             $('.js-form-validation-message').html('');

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -115,8 +115,10 @@
             validateNotEmpty.call(this);
         };
 		var validateDescriptionText = function validateDescriptionText(){
-            if($(this).val().length() > 100) {
-                errorMessages.push('Re-run description must be less than 100 characters.')
+			var max_length = 50;
+            if($(this).val().length > max_length) {
+				isValid = false;
+                errorMessages.push('Re-run description must be less than ' + max_length.toString() + ' characters.')
             }
         };
         var validateNumber = function validateNumber(){
@@ -179,7 +181,7 @@
         $form.find('[data-type="boolean"]').each(validateBoolean);
         $form.find('[data-type="list_number"]').each(validateListNumber);
         $form.find('[data-type="list_text"]').each(validateListText);
-		$form.find('[nodeValue="run_description').each(validateDescriptionText);
+		$form.find('[name="run_description"]').each(validateDescriptionText);
 
         if(!isValid){
             $('.js-form-validation-message').html('');

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -116,7 +116,7 @@
         };
 		var validateDescriptionText = function validateDescriptionText(){
             if($(this).val().length() > 100) {
-                errorMessages.push(getVarName('Re-run description must be less than 100 characters.')
+                errorMessages.push('Re-run description must be less than 100 characters.')
             }
         };
         var validateNumber = function validateNumber(){

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -114,10 +114,10 @@
         var validateText = function validateText(){
             validateNotEmpty.call(this);
         };
-		var validateDescriptionText = function validateDescriptionText(){
-			var max_length = 50;
+        var validateDescriptionText = function validateDescriptionText(){
+            var max_length = 50;
             if($(this).val().length > max_length) {
-				isValid = false;
+                isValid = false;
                 errorMessages.push('Re-run description must be less than ' + max_length.toString() + ' characters.')
             }
         };
@@ -181,7 +181,7 @@
         $form.find('[data-type="boolean"]').each(validateBoolean);
         $form.find('[data-type="list_number"]').each(validateListNumber);
         $form.find('[data-type="list_text"]').each(validateListText);
-		$form.find('[name="run_description"]').each(validateDescriptionText);
+        $form.find('[name="run_description"]').each(validateDescriptionText);
 
         if(!isValid){
             $('.js-form-validation-message').html('');

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -116,7 +116,7 @@
         };
         var validateDescriptionText = function validateDescriptionText(){
             var max_length = 50;
-            if($(this).val().length > max_length) {
+            if($(this).val().length >= max_length) {
                 isValid = false;
                 errorMessages.push('Re-run description must be less than ' + max_length.toString() + ' characters.')
             }


### PR DESCRIPTION
Fixes #114 

The 500 error was actually being produced at 50 chars, rather than the 100 discussed in the issue. The form can now not be submitted if it has a description longer than 50 characters, a suitable error message is then shown. 

**To test:** Attempt to submit a re-run with greater than 50 characters.  