### PR TITLE
End Of Run Monitoring Script

### DIFF
--- a/ReductionScripts/sns/cncs/reduce_CNCS.py
+++ b/ReductionScripts/sns/cncs/reduce_CNCS.py
@@ -70,8 +70,8 @@ DGSdict['DetVanIntRangeUnits']='TOF'
 DGSdict['OutputWorkspace']='reduce'
 DGSdict['TibTofRangeStart']=tib[0]
 DGSdict['TibTofRangeEnd']=tib[1]
-#DGSdict['TimeIndepBackgroundSub']=True
-DGSdict['TimeIndepBackgroundSub']=False
+DGSdict['TimeIndepBackgroundSub']=True
+#DGSdict['TimeIndepBackgroundSub']=False
 
 DgsReduction(**DGSdict)
 NormalizedVanadiumEqualToOne = True

--- a/scripts/EndOfRunMonitor/ISIS_monitor_daemon.py
+++ b/scripts/EndOfRunMonitor/ISIS_monitor_daemon.py
@@ -1,0 +1,25 @@
+from daemon import Daemon
+import sys, time
+import ISISendOfRunMonitor
+
+
+class InstrumentMonitorDaemon(Daemon):
+    def run(self):
+        ISISendOfRunMonitor.main()
+
+if __name__ == "__main__":
+    daemon = InstrumentMonitorDaemon('/tmp/InstrumentMonitorDaemon.pid')
+    if len(sys.argv) == 2:
+        if 'start' == sys.argv[1]:
+            daemon.start()
+        elif 'stop' == sys.argv[1]:
+            daemon.stop()
+        elif 'restart' == sys.argv[1]:
+            daemon.restart()
+        else:
+            print "Unknown command"
+            sys.exit(2)
+        sys.exit(0)
+    else:
+        print "usage: %s start|stop|restart" % sys.argv[0]
+        sys.exit(2)

--- a/scripts/EndOfRunMonitor/ISIS_monitor_win_service.py
+++ b/scripts/EndOfRunMonitor/ISIS_monitor_win_service.py
@@ -1,0 +1,46 @@
+import win32service
+import win32serviceutil
+import win32api
+import win32con
+import win32event
+import win32evtlogutil
+import os
+import ISISendOfRunMonitor
+
+class QueueService(win32serviceutil.ServiceFramework):
+    _svc_name_ = "AutoreduceInstrumentMonitor"
+    _svc_display_name_ = "Autoreduce Instrument Monitor"
+    _svc_description_ = ""
+
+
+    def __init__(self, args):
+        win32serviceutil.ServiceFramework.__init__(self, args)
+        self.hWaitStop = win32event.CreateEvent(None, 0, 0, None)           
+
+    def SvcStop(self):
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        win32event.SetEvent(self.hWaitStop)                    
+         
+    def SvcDoRun(self):
+        import servicemanager      
+        servicemanager.LogMsg(servicemanager.EVENTLOG_INFORMATION_TYPE,servicemanager.PYS_SERVICE_STARTED,(self._svc_name_, '')) 
+
+        self.timeout = 3000
+        client = ISISendOfRunMonitor.main()
+        
+        while 1:
+            # Wait for service stop signal, if I timeout, loop again
+            rc = win32event.WaitForSingleObject(self.hWaitStop, self.timeout)
+            # Check to see if self.hWaitStop happened
+            if rc == win32event.WAIT_OBJECT_0:
+                client.stop()
+                # Stop signal encountered
+                servicemanager.LogInfoMsg(self._svc_name_ + " - STOPPED")
+                break
+
+def ctrlHandler(ctrlType):
+    return True
+
+if __name__ == '__main__':   
+    win32api.SetConsoleCtrlHandler(ctrlHandler, True)   
+    win32serviceutil.HandleCommandLine(QueueService)

--- a/scripts/EndOfRunMonitor/ISIS_monitor_win_service.py
+++ b/scripts/EndOfRunMonitor/ISIS_monitor_win_service.py
@@ -26,17 +26,16 @@ class QueueService(win32serviceutil.ServiceFramework):
         servicemanager.LogMsg(servicemanager.EVENTLOG_INFORMATION_TYPE,servicemanager.PYS_SERVICE_STARTED,(self._svc_name_, '')) 
 
         self.timeout = 3000
-        client = ISISendOfRunMonitor.main()
-        
+        ISISendOfRunMonitor.main()
         while 1:
             # Wait for service stop signal, if I timeout, loop again
             rc = win32event.WaitForSingleObject(self.hWaitStop, self.timeout)
             # Check to see if self.hWaitStop happened
             if rc == win32event.WAIT_OBJECT_0:
-                client.stop()
                 # Stop signal encountered
                 servicemanager.LogInfoMsg(self._svc_name_ + " - STOPPED")
                 break
+
 
 def ctrlHandler(ctrlType):
     return True

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -97,7 +97,8 @@ class InstrumentMonitor(threading.Thread):
             self.client.send('/queue/DataReady', json.dumps(data_dict))
         logging.info("Data sent: " + str(data_dict))
 
-if __name__ == "__main__":
+
+def main():
     activemq_client = StompClient([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
     activemq_client.connect()
 
@@ -105,3 +106,6 @@ if __name__ == "__main__":
     for inst in INSTRUMENTS:
         file_monitor = InstrumentMonitor(inst, activemq_client, message_lock)
         file_monitor.start()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -53,21 +53,19 @@ class ISIS_Instrument_Monitor(object):
             log.write(str(message))
 
     def monitor(self):
-        """ Works to actually monitor the file, like 'tail -f'
+        """ Works to actually monitor the file
         """
         with open(self.instrumentLastRunLocat) as file:
-            file.seek(0, 2)  # Go to end of file
+            last_run = file.readline().split()[1]
             while True:  # send thread to sleep, use Timer objects
+                time.sleep(TIME_CONSTANT)
+                file.seek(0, 0)
                 line = file.readline()
-                if not line:
-                    time.sleep(TIME_CONSTANT)
-                    continue
-                if not self._has_ended(line):
-                    file.seek(-len(line), 2)  # Move back a line
-                    time.sleep(TIME_CONSTANT)
-                    continue
-                self.lastRunData = line
-                self.send_message()
+                data = line.split()
+                if (data[1] != last_run) and (int(data[2]) == 0):
+                    last_run = data[1]
+                    self.lastRunData = line
+                    self.send_message()
 
     def _has_ended(self, line):
         """ Function to check that the run has actually ended (runs with >0 in the line have only updated/stored)

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -1,4 +1,4 @@
-import time, json, os, logging
+import time, json, os, logging, sys
 from Stomp_Client import StompClient
 import threading
 
@@ -93,18 +93,15 @@ class InstrumentMonitor(threading.Thread):
         """
         with self.lock:
             data_dict = self.build_dict(last_run_data)
-        # self.client.send('/queue/DataReady', json.dumps(data_dict))
+        if not DEBUG:
+            self.client.send('/queue/DataReady', json.dumps(data_dict))
         logging.info("Data sent: " + str(data_dict))
 
-activemq_client = StompClient([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
-activemq_client.connect()
+if __name__ == "__main__":
+    activemq_client = StompClient([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
+    activemq_client.connect()
 
-message_lock = threading.Lock()
-monitors = []
-for inst in INSTRUMENTS:
-    file_monitor = InstrumentMonitor(inst, activemq_client, message_lock)
-    file_monitor.start()
-    monitors.append(file_monitor)
-
-while 1:
-    pass
+    message_lock = threading.Lock()
+    for inst in INSTRUMENTS:
+        file_monitor = InstrumentMonitor(inst, activemq_client, message_lock)
+        file_monitor.start()

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -1,0 +1,84 @@
+import time, Stomp_Client, json, twisted
+#Config settings for cycle number, and instrument file arrangement
+cycleNum = "14_3"
+instrumentFile = "\\isis\inst$\NDXMERLIN\Instrument\data\cycle_14_3\%s.nxs"
+activemq_client = Stomp_Client([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
+activemq_client.connect()
+        
+        
+
+class ISIS_Instrument_Monitor(object):
+    def __init__(self, instrumType):
+        self.InstrumentType = instrumType
+        self.instrumentFile = self.setInstrumFile()
+        self.instrumentSummaryLocat = self.instrumentFile + "\logs\journal\SUMMARY.txt"
+        self.instrumentLastRunLocat = self.instrumentFile + "\logs\lastrun.txt"    
+        
+    def setInstrumFile(self):
+        instrumentFolder = "\\isis\inst$\NDX%s\Instrument" % self.InstrumentType
+        return instrumentFolder
+        
+    def queryBuilder(self):
+        """ Uses information from lastRun file, 
+        and last line of the summary text file to build the query 
+        """ 
+        lastRun = self.lastRunData.split()
+        self.runNum = lastRun[1]
+        lastSummary = self.lastSummary.split()
+        self.RBNum = lastSummary[7]
+        fileName = ''.join(lastRun[0:2]) #so MER111 etc
+        self.runDataLocat = instrumentFile % fileName # need to chnge this
+
+        
+    def getRBNum(self):
+        """ Reads last line of summary.txt file 
+        """
+        summaryTxt = self.instrumentSummaryLocat
+        with open(summaryTxt, 'rb') as st:
+            for line in st:
+                pass
+            self.lastSummary = line
+        
+
+    
+    def writeToFile(self, dicto):
+        """ Works as logger of dict files
+        """
+        with open("test.txt", 'w') as testtxt:
+            testtxt.write(str(dicto))
+    
+        
+    def messager(self):
+        """Puts message together and sends it, along with logging
+        """
+        self.queryBuilder()
+        data_dict = {
+      "rb_number": self.RBNum,
+      "instrument": "MERLIN",
+      "data": self.runDataLocat,
+      "run_number": self.runNum,
+      "facility": "ISIS"
+        }
+        #activemq_client.send('/queue/DataReady', json.dumps(data_dict))
+        print data_dict
+        self.writeToFile(data_dict)
+    
+    def monitor(self):
+        """ Works to actually monitor the file, like 'tail -f'
+        """
+        file = self.instrumentLastRunLocat
+        file.seek(0,2)
+        while True: #send thread to sleep, use Timer objects
+            line = file.readline()
+            if not line:
+                time.sleep(0.1) 
+                continue
+            yield line
+            line = self.lastRunData
+            self.messager()
+#instrumentName = "MERLIN"  
+#lastSummary = "MER25101Adroja,             CeFe2Al10 40meV 200Hz 5K04-MAY-2015 16:52:39     6.9 1510145"  
+#lastRun = "MER 25101 0"
+logfile = open('lastrun.txt', 'r')
+lastRun = monitor(logfile)    
+

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -99,7 +99,7 @@ class InstrumentMonitor(threading.Thread):
 
 
 def main():
-    activemq_client = StompClient([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
+    activemq_client = StompClient([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', 'xxxxxxxxx', 'RUN_BACKLOG')
     activemq_client.connect()
 
     message_lock = threading.Lock()

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -8,11 +8,11 @@ INST_FOLDER = "\\\\isis\inst$\NDX%s\Instrument"
 DATA_LOC = "\data\cycle_%s\\" % CYCLE_NUM
 SUMMARY_LOC = "\logs\journal\SUMMARY.txt"
 LAST_RUN_LOC = "\logs\lastrun.txt"
-LOG_FILE = "monitor_log.txt"
+LOG_FILE = "C:\\autoreduce\\scripts\\EndOfRunMonitor\\monitor_log.txt"
 USE_NXS = True
-INSTRUMENTS = ['MERLIN', 'WISH', 'LET', 'MAPS']
+INSTRUMENTS = ['LET']
 TIME_CONSTANT = 1  # Time between file reads (in seconds)
-DEBUG = True
+DEBUG = False
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
 
 

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -1,19 +1,21 @@
 import time, json, datetime
 from Stomp_Client import Stomp_Client
 
-#Config settings for cycle number, and instrument file arrangement
+# Config settings for cycle number, and instrument file arrangement
 CYCLE_NUM = "14_3"
 INST_FOLDER = "\\isis\inst$\NDX%s\Instrument"
 DATA_LOC = "\data\cycle_%s\\" % CYCLE_NUM
 SUMMARY_LOC = "\logs\journal\SUMMARY.txt"
 LAST_RUN_LOC = "\logs\lastrun.txt"
+USE_NXS = True
+TIME_CONSTANT = 1  # Time between file reads (in seconds)
 
 class ISIS_Instrument_Monitor(object):
     def __init__(self, instrumentName, client):
         self.client = client
         self.instrumentName = instrumentName
         self.instrumentFolder = '.'
-        #self.instrumentFolder = INST_FOLDER % self.instrumentName
+        # self.instrumentFolder = INST_FOLDER % self.instrumentName
         self.instrumentSummaryLocat = self.instrumentFolder + SUMMARY_LOC
         self.instrumentLastRunLocat = self.instrumentFolder + LAST_RUN_LOC
         self.instrumentDataFolderLoc = self.instrumentFolder + DATA_LOC
@@ -25,8 +27,15 @@ class ISIS_Instrument_Monitor(object):
         lastRun = self.lastRunData.split()
         self.runNum = lastRun[1]
         self.RBNum = self._getRBNum()
-        fileName = ''.join(lastRun[0:2]) #so MER111 etc
-        self.runDataLocat = self.instrumentDataFolderLoc + fileName + ".nxs"
+        fileName = ''.join(lastRun[0:2])  # so MER111 etc
+        self.runDataLocat = self.instrumentDataFolderLoc + fileName + self._get_file_extension()
+
+    def _get_file_extension(self):
+        """ Choose the data extension based on the global boolean"""
+        if USE_NXS:
+            return ".nxs"
+        else:
+            return ".raw"
 
     def _getRBNum(self):
         """ Reads last line of summary.txt file and returns the RB number
@@ -47,16 +56,29 @@ class ISIS_Instrument_Monitor(object):
         """ Works to actually monitor the file, like 'tail -f'
         """
         with open(self.instrumentLastRunLocat) as file:
-            file.seek(0, 2) #Go to end of file
-            while True: #send thread to sleep, use Timer objects
+            file.seek(0, 2)  # Go to end of file
+            while True:  # send thread to sleep, use Timer objects
                 line = file.readline()
                 if not line:
-                    time.sleep(1)
+                    time.sleep(TIME_CONSTANT)
+                    continue
+                if not self._has_ended(line):
+                    file.seek(-len(line), 2)  # Move back a line
+                    time.sleep(TIME_CONSTANT)
                     continue
                 self.lastRunData = line
-                self.messager()
+                self.send_message()
 
-    def messager(self):
+    def _has_ended(self, line):
+        """ Function to check that the run has actually ended (runs with >0 in the line have only updated/stored)
+        These are ignored for now but could be autoreduced eventually
+        """
+        if int(line.split()[-1]) == 0:
+            return True
+        else:
+            return False
+
+    def send_message(self):
         """Puts message together and sends it, along with logging
         """
         self.queryBuilder()
@@ -67,11 +89,11 @@ class ISIS_Instrument_Monitor(object):
             "run_number": self.runNum,
             "facility": "ISIS"
         }
-        #self.client.send('/queue/DataReady', json.dumps(data_dict))
+        # self.client.send('/queue/DataReady', json.dumps(data_dict))
         print data_dict
         self.writeToFile(data_dict)
 
 activemq_client = Stomp_Client([("autoreduce.isis.cclrc.ac.uk", 61613)], 'autoreduce', '1^G8r2b$(6', 'RUN_BACKLOG')
 activemq_client.connect()
-file_monitor = ISIS_Instrument_Monitor('', activemq_client)
+file_monitor = ISIS_Instrument_Monitor('MERLIN', activemq_client)
 file_monitor.monitor()

--- a/scripts/EndOfRunMonitor/README.md
+++ b/scripts/EndOfRunMonitor/README.md
@@ -1,0 +1,18 @@
+End of Run Script
+==========
+
+This script periodically checks the lastrun.txt file on selected instruments and sends a message to the DataReady queue when runs end.
+
+## Windows Installation as a service
+
+1. In an administrative command prompt navigate to the autoreduce_webapp folder
+2. `python ISIS_monitor_win_service.py install`
+3. Open Services, right click on "Autoreduce Instrument Monitor" and select Properties
+4. Change Startup Type to Automatic
+5. On the 'Log On' tab change to 'This Account'
+6. From the 'Browse...' window select 'Locations...' then fed.cclrc.ac.uk
+7. Enter your fedID and click 'Check Names' then 'Ok'
+8. Enter your fedID password into both boxes
+9. Click Start
+
+

--- a/scripts/EndOfRunMonitor/Stomp_Client.py
+++ b/scripts/EndOfRunMonitor/Stomp_Client.py
@@ -41,7 +41,5 @@ class Stomp_Client(object):
         self._connection = None
 
     def send(self, destination, message, persistent='true'):
-        if self._connection is None or not self._connection.is_connected():
-            self._disconnect()
-            self._connection = self.get_connection()
+        self.connect()
         self._connection.send(destination, message, persistent=persistent)

--- a/scripts/EndOfRunMonitor/Stomp_Client.py
+++ b/scripts/EndOfRunMonitor/Stomp_Client.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed May 27 14:37:59 2015
+
+@author: xxu30744
+"""
+import time, stomp
+
+class Stomp_Client(object):
+    def __init__(self, brokers, user, password, topics=None, consumer_name='QueueProcessor'):
+        self._brokers = brokers
+        self._user = user
+        self._password = password
+        self._connection = None
+        self._topics = topics
+        self._consumer_name = consumer_name
+        self._listener = None
+
+    def get_connection(self):
+        connection = stomp.Connection(host_and_ports=self._brokers, use_ssl=True, ssl_version=3)
+        connection.start()
+        connection.connect(self._user, self._password, wait=False)
+
+        time.sleep(0.5)
+        return connection
+
+    def connect(self):
+        if self._connection is None or not self._connection.is_connected():
+            self._disconnect()
+            self._connection = self.get_connection()
+
+    def _disconnect(self):
+        if self._connection is not None and self._connection.is_connected():
+            self._connection.disconnect()
+        self._connection = None
+
+    def stop(self):
+        self._disconnect()
+        if self._connection is not None:
+            self._connection.stop()
+        self._connection = None
+
+    def send(self, destination, message, persistent='true'):
+        if self._connection is None or not self._connection.is_connected():
+            self._disconnect()
+            self._connection = self.get_connection()
+        self._connection.send(destination, message, persistent=persistent)

--- a/scripts/EndOfRunMonitor/Stomp_Client.py
+++ b/scripts/EndOfRunMonitor/Stomp_Client.py
@@ -6,7 +6,8 @@ Created on Wed May 27 14:37:59 2015
 """
 import time, stomp
 
-class Stomp_Client(object):
+
+class StompClient(object):
     def __init__(self, brokers, user, password, topics=None, consumer_name='QueueProcessor'):
         self._brokers = brokers
         self._user = user


### PR DESCRIPTION
Fixes #129.

The script creates a thread for each instrument that periodically reads a file provided by instrument controls. This file is updated when runs are complete and from this it will send a query to the DataReady queue.

**To test:** Set the DEBUG variable to False and the INSTRUMENTS variable to a chosen instrument, specifying whether the instrument uses a nexus file or not. Have a run end on the chosen instrument whilst the script is running, this will then be queued for autoreduction.