### PR TITLE
EndOfRun.py: Automatically find latest cycle

### DIFF
--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -3,7 +3,6 @@ from Stomp_Client import StompClient
 import threading
 
 # Config settings for cycle number, and instrument file arrangement
-CYCLE_NUM = ""
 INST_FOLDER = "\\\\isis\inst$\NDX%s\Instrument"
 DATA_LOC = "\data\cycle_%s\\"
 SUMMARY_LOC = "\logs\journal\SUMMARY.txt"

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -3,13 +3,18 @@ from Stomp_Client import StompClient
 import threading
 
 # Config settings for cycle number, and instrument file arrangement
-CYCLE_NUM = "14_3"
+CYCLE_NUM = ""
 INST_FOLDER = "\\\\isis\inst$\NDX%s\Instrument"
-DATA_LOC = "\data\cycle_%s\\" % CYCLE_NUM
+DATA_LOC = "\data\cycle_%s\\"
 SUMMARY_LOC = "\logs\journal\SUMMARY.txt"
 LAST_RUN_LOC = "\logs\lastrun.txt"
-LOG_FILE = "C:\\autoreduce\\scripts\\EndOfRunMonitor\\monitor_log.txt"
-INSTRUMENTS = [{'name': 'LET', 'use_nexus': True}, {'name': 'MERLIN', 'use_nexus': False}]
+LOG_FILE = "C:\\monitor_log.txt"
+INSTRUMENTS = [{'name': 'LET', 'use_nexus': True},
+               {'name': 'MERLIN', 'use_nexus': False},
+               {'name': 'MARI', 'use_nexus': False},
+               {'name': 'MAPS', 'use_nexus': True},
+               {'name': 'WISH', 'use_nexus': True},
+               {'name': 'GEM', 'use_nexus': True}]
 TIME_CONSTANT = 1  # Time between file reads (in seconds)
 DEBUG = False
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
@@ -43,9 +48,17 @@ class InstrumentMonitor(threading.Thread):
             self.instrumentFolder = INST_FOLDER % self.instrumentName
         self.instrumentSummaryLoc = self.instrumentFolder + SUMMARY_LOC
         self.instrumentLastRunLoc = self.instrumentFolder + LAST_RUN_LOC
-        self.instrumentDataFolderLoc = self.instrumentFolder + DATA_LOC
+        self.instrumentDataFolderLoc = self.instrumentFolder + DATA_LOC % self._get_most_recent_cycle()
         self.lock = lock
-        
+
+    def _get_most_recent_cycle(self):
+        folders = os.listdir(self.instrumentFolder + '\logs\\')
+        cycle_folders = [f for f in folders if f.startswith('cycle')]
+
+        # List should have most recent cycle at the end
+        most_recent = cycle_folders[-1]
+        return most_recent[most_recent.find('_')+1:]
+
     def build_dict(self, last_run_data):
         """ Uses information from lastRun file, 
         and last line of the summary text file to build the query 

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -7,7 +7,7 @@ INST_FOLDER = "\\\\isis\inst$\NDX%s\Instrument"
 DATA_LOC = "\data\cycle_%s\\"
 SUMMARY_LOC = "\logs\journal\SUMMARY.txt"
 LAST_RUN_LOC = "\logs\lastrun.txt"
-LOG_FILE = "C:\\monitor_log.txt"
+LOG_FILE = "xx\\monitor_log.txt"
 INSTRUMENTS = [{'name': 'LET', 'use_nexus': True},
                {'name': 'MERLIN', 'use_nexus': False},
                {'name': 'MARI', 'use_nexus': False},

--- a/scripts/EndOfRunMonitor/README.md
+++ b/scripts/EndOfRunMonitor/README.md
@@ -7,14 +7,15 @@ This script periodically checks the lastrun.txt file on selected instruments and
 
 Python modules required: pywin32 and stomp.py
 
-1. In an administrative command prompt navigate to the autoreduce_webapp folder
-2. `python ISIS_monitor_win_service.py install`
-3. Open Services, right click on "Autoreduce Instrument Monitor" and select Properties
-4. Change Startup Type to Automatic
-5. On the 'Log On' tab change to 'This Account'
-6. From the 'Browse...' window select 'Locations...' then fed.cclrc.ac.uk
-7. Enter your fedID and click 'Check Names' then 'Ok'
-8. Enter your fedID password into both boxes
-9. Click Start
+1. Edit the LOG_FILE location in the script to point to a sensible directory
+2. In an administrative command prompt navigate to the autoreduce_webapp folder
+3. `python ISIS_monitor_win_service.py install`
+4. Open Services, right click on "Autoreduce Instrument Monitor" and select Properties
+5. Change Startup Type to Automatic
+6. On the 'Log On' tab change to 'This Account'
+7. From the 'Browse...' window select 'Locations...' then fed.cclrc.ac.uk
+8. Enter your fedID and click 'Check Names' then 'Ok'
+9. Enter your fedID password into both boxes
+10. Click Start
 
-
+Note: The service will have to be restarted at the beginning of a new cycle to pick up the cycle number


### PR DESCRIPTION
Fixes #149.

To test: Set up the End Of Run script and wait for a run to end. The data should now be coming from the latest cycle rather than a hard-coded one