### PR TITLE
Update WebApp's cached script if out of date

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -202,9 +202,13 @@ class InstrumentVariablesUtils(object):
 
         logger.info("Reduce cache modded %s" % script_cache_mod)
         logger.info("Reduce file modded %s" % script_file_mod)
+        logging.info("Reduce cache modded %s" % script_cache_mod)
+        logging.info("Reduce file modded %s" % script_file_mod)
 
         logger.info("Vars cache modded %s" % script_vars_cache_mod)
         logger.info("Vars file modded %s" % script_vars_file_mod)
+        logging.info("Vars cache modded %s" % script_vars_cache_mod)
+        logging.info("Vars file modded %s" % script_vars_file_mod)
 
         script_binary = self.__load_reduction_script(variable.instrument.name)
         reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(variable.instrument.name)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -181,17 +181,30 @@ class InstrumentVariablesUtils(object):
             notification.save()
             return None, None
 
+    def __get_scripts_modified(self, instrument_name):
+        """
+        Returns the last modification time of the scripts located in the filesystem
+        """
+        reduction_file = os.path.join((REDUCTION_DIRECTORY % (instrument_name)), "reduce.py")
+        script_mod_time = os.path.getmtime(reduction_file)
+        reduction_file = os.path.join((REDUCTION_DIRECTORY % (instrument_name)), "reduce_vars.py")
+        script_vars_mod_time = os.path.getmtime(reduction_file)
+        return script_mod_time, script_vars_mod_time
+
     def __check_script_up_to_date(self, variables):
         """
         Reloads script in variables to match that on disk (inefficient)
         """
+        variable = variables[0]  # Assume script will be the same for all variables
 
-        logging.info("Reloading script from disk")
-        logger.info("Reloading script from disk")
+        script_cache_mod, script_vars_cache_mod = ScriptUtils.get_script_modified(variable.scripts)
+        script_file_mod, script_vars_file_mod = self.__get_script_modified(variable.instrument.name)
 
-        variable = variables[0]  # Script will be the same for all variables
+        logger.info("Reduce cache modded %s" % script_cache_mod)
+        logger.info("Reduce file modded %s" % script_file_mod)
 
-        #script_mod, script_vars_mod = ScriptUtils.get_script_modified(variable.scripts)
+        logger.info("Vars cache modded %s" % script_vars_cache_mod)
+        logger.info("Vars file modded %s" % script_vars_file_mod)
 
         script_binary = self.__load_reduction_script(variable.instrument.name)
         reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(variable.instrument.name)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -457,10 +457,15 @@ class ScriptUtils(object):
         """
         script_modified = None
         script_vars_modified = None
-        time_format = "%Y-%m-%d %H:%M:%S"
+
         for script in scripts:
             if script.file_name == "reduce.py":
-                script_modified = int(time.mktime(time.strptime(script.created, time_format)))
+                script_modified = self._convert_time_from_string(str(script.created))
             elif script.file_name == "reduce_vars.py":
-                script_vars_modified = int(time.mktime(time.strptime(script.created, time_format)))
+                script_vars_modified = self._convert_time_from_string(str(script.created))
         return script_modified, script_vars_modified
+
+    def _convert_time_from_string(self, string_time):
+        time_format = "%Y-%m-%d %H:%M:%S"
+        string_time = string_time[:string_time.find('+')]
+        return int(time.mktime(time.strptime(string_time, time_format)))

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -209,23 +209,13 @@ class InstrumentVariablesUtils(object):
         script_cache_mod, script_vars_cache_mod = ScriptUtils().get_cache_scripts_modified(variable.scripts.all())
         script_file_mod, script_vars_file_mod = self.__get_scripts_modified(variable.instrument.name)
 
-        logger.info("Reduce cache modded %s" % script_cache_mod)
-        logger.info("Reduce file modded %s" % script_file_mod)
-        logging.info("Reduce cache modded %s" % script_cache_mod)
-        logging.info("Reduce file modded %s" % script_file_mod)
-
-        logger.info("Vars cache modded %s" % script_vars_cache_mod)
-        logger.info("Vars file modded %s" % script_vars_file_mod)
-        logging.info("Vars cache modded %s" % script_vars_cache_mod)
-        logging.info("Vars file modded %s" % script_vars_file_mod)
-
         if script_cache_mod < script_file_mod:
-            logging.info("Reduce.py script out of date, reloading")
+            logger.info("Reduce.py script out of date, reloading")
             script_binary = self.__load_reduction_script(variable.instrument.name)
             self.__add_new_script_to_variables(variables, script_binary, 'reduce.py')
 
         if script_vars_cache_mod < script_vars_file_mod:
-            logging.info("Reduce_vars.py script out of date, reloading")
+            logger.info("Reduce_vars.py script out of date, reloading")
             reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(variable.instrument.name)
             self.__add_new_script_to_variables(variables, vars_script_binary, 'reduce_vars.py')
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -187,6 +187,7 @@ class InstrumentVariablesUtils(object):
         """
 
         logging.info("Reloading script from disk")
+        logger.info("Reloading script from disk")
 
         variable = variables[0]  # Script will be the same for all variables
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -36,6 +36,16 @@ def write_script_to_temp(script, script_vars_file):
         raise e
     return script_path
 
+
+def log_error_and_notify(message):
+    """
+    Helper method to log an error and save a notifcation
+    """
+    logger.error(message)
+    notification = Notification(is_active=True, is_staff_only=True, severity='e', message=message)
+    notification.save()
+
+
 class VariableUtils(object):
     def wrap_in_type_syntax(self, value, var_type):
         """
@@ -124,6 +134,7 @@ class VariableUtils(object):
             return "list_" + list_type
         return "text"
 
+
 class InstrumentVariablesUtils(object):
     def __load_reduction_script(self, instrument_name):
         """
@@ -135,21 +146,15 @@ class InstrumentVariablesUtils(object):
         try:
             f = open(reduction_file, 'rb')
             script_binary = f.read()
-            return  script_binary
+            return script_binary
         except ImportError, e:
-            logger.error("Unable to load reduction script %s due to missing import. (%s)" % (reduction_file, e.message))
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Unable to open reduction script for %s due to import error. (%s)" % (instrument_name, e.message))
-            notification.save()
+            log_error_and_notify("Unable to load reduction script %s due to missing import. (%s)" % (reduction_file, e.message))
             return None
         except IOError:
-            logger.error("Unable to load reduction script %s" % reduction_file)
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Unable to open reduction script for %s" % instrument_name)
-            notification.save()
+            log_error_and_notify("Unable to load reduction script %s" % reduction_file)
             return None
         except SyntaxError:
-            logger.error("Syntax error in reduction script %s" % reduction_file)
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Syntax error in reduction script for %s" % instrument_name)
-            notification.save()
+            log_error_and_notify("Syntax error in reduction script %s" % reduction_file)
             return None
 
     def __load_reduction_vars_script(self, instrument_name):
@@ -166,28 +171,22 @@ class InstrumentVariablesUtils(object):
             script_binary = f.read()
             return reduce_script, script_binary
         except ImportError, e:
-            logger.error("Unable to load reduction script %s due to missing import. (%s)" % (reduction_file, e.message))
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Unable to open reduction script for %s due to import error. (%s)" % (instrument_name, e.message))
-            notification.save()
+            log_error_and_notify("Unable to load reduction script %s due to missing import. (%s)" % (reduction_file, e.message))
             return None, None
         except IOError:
-            logger.error("Unable to load reduction script %s" % reduction_file)
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Unable to open reduction script for %s" % instrument_name)
-            notification.save()
+            log_error_and_notify("Unable to load reduction script %s" % reduction_file)
             return None, None
         except SyntaxError:
-            logger.error("Syntax error in reduction script %s" % reduction_file)
-            notification = Notification(is_active=True, is_staff_only=True,severity='e', message="Syntax error in reduction script for %s" % instrument_name)
-            notification.save()
+            log_error_and_notify("Syntax error in reduction script %s" % reduction_file)
             return None, None
 
     def __get_scripts_modified(self, instrument_name):
         """
         Returns the last modification time of the scripts located in the filesystem
         """
-        reduction_file = os.path.join((REDUCTION_DIRECTORY % (instrument_name)), "reduce.py")
+        reduction_file = os.path.join((REDUCTION_DIRECTORY % instrument_name), "reduce.py")
         script_mod_time = os.path.getmtime(reduction_file)
-        reduction_file = os.path.join((REDUCTION_DIRECTORY % (instrument_name)), "reduce_vars.py")
+        reduction_file = os.path.join((REDUCTION_DIRECTORY % instrument_name), "reduce_vars.py")
         script_vars_mod_time = os.path.getmtime(reduction_file)
         return script_mod_time, script_vars_mod_time
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -185,6 +185,9 @@ class InstrumentVariablesUtils(object):
         """
         Reloads script in variables to match that on disk (inefficient)
         """
+
+        logging.info("Reloading script from disk")
+
         variable = variables[0]  # Script will be the same for all variables
 
         #script_mod, script_vars_mod = ScriptUtils.get_script_modified(variable.scripts)


### PR DESCRIPTION
Fixes #135 

**To Test:** 
* Send a job using a trigger script (on an instrument that has a working reduce.py script)
* Once the job has finished modify the relevant reduce.py script to give an error
* Send a new job with the trigger script
* A "Reduce.py script out of date, reloading" message should appear in the WebApp logs
* The new job should throw the error expected from the reduce.py script
* Send another job without modifying the reduce.py script
* Confirm no "Reduce.py script out of date, reloading" message is displayed in the logs (this shows the script is only reloaded if necessary)
* Modify the reduce.py script to correct the previously introduced error