### PR TITLE
Added message priorities to ActiveMQ 

### DIFF
--- a/WebApp/ISIS/README.md
+++ b/WebApp/ISIS/README.md
@@ -69,8 +69,8 @@ Recommended Server OS: Red Hat Enterprise Linux (RHEL) 6 / 7
 
 ### Configure ActiveMQ
 1. `adduser --system activemq`
-2. `chown -R activemq: /opt/apache-activemq-5.9.1/`
-3. `nano /opt/apache-activemq-5.9.1/conf/activemq.xml`
+2. `chown -R activemq: /opt/activemq/`
+3. `nano /opt/activemq/conf/activemq.xml`
 4. Change 
 
 
@@ -155,7 +155,7 @@ Recommended Server OS: Red Hat Enterprise Linux (RHEL) 6 / 7
 8. `chmod +x /etc/init.d/activemqstart.sh && chmod +x /etc/init.d/activemqstop.sh && chmod +x /etc/init.d/activemq`
 9. `chkconfig --add activemq`
 10. `chkconfig activemq on`
-11. `/opt/apache-activemq-5.9.1/bin/activemq setup /etc/default/activemq`
+11. `/opt/activemq/bin/activemq setup /etc/default/activemq`
 12. `chown root /etc/default/activemq`
 13. `chmod 600 /etc/default/activemq`
 14. `lokkit --port=61613:tcp` RHEL6 Only
@@ -173,7 +173,7 @@ Recommended Server OS: Red Hat Enterprise Linux (RHEL) 6 / 7
         received a message
 
 ### Setting credentials for ActiveMQ
-1. `nano /opt/apache-activemq-5.9.1/conf/activemq.xml`
+1. `nano /opt/activemq/conf/activemq.xml`
 2. Include the following within the `<broker>` tag with the desired values
         
         <plugins>
@@ -185,6 +185,9 @@ Recommended Server OS: Red Hat Enterprise Linux (RHEL) 6 / 7
             </simpleAuthenticationPlugin>
         </plugins>
 
+### Setting up Priority Queues for ActiveMQ
+1. `nano /opt/activemq/conf/activemq.xml`
+2. Within the `<policyEntries>` tag include `<policyEntry queue=">" queuePrefetch="1" prioritizedMessages="true" useCache="false" expireMessagesPeriod="0"/>`
 
 ### Installing ICAT support
 1. `hg clone https://AverageMarcus@bitbucket.org/AverageMarcus/suds -u release-0.6.1`

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -433,7 +433,7 @@ class MessagingUtils(object):
             'facility':FACILITY,
             'message':'',
         }
-        message_client.send('/queue/ReductionPending', json.dumps(data_dict))    
+        message_client.send('/queue/ReductionPending', json.dumps(data_dict), priority='0')
         message_client.stop()
 
 class ScriptUtils(object):

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -106,7 +106,7 @@ class InstrumentMonitor(threading.Thread):
         with self.lock:
             data_dict = self.build_dict(last_run_data)
         if not DEBUG:
-            self.client.send('/queue/DataReady', json.dumps(data_dict))
+            self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
         logging.info("Data sent: " + str(data_dict))
 
 


### PR DESCRIPTION
Fixes #111 

Jobs re run from the WebApp now have a priority of 0, jobs from the EndOfRun have priority 9. The default for misc sends is 4. The jobs with high priority number will be taken from the ReductionPending queue first.

To Test:
* Modify the a trigger script to send priority messages as seen in the send method of queue_processor.py (I can email a modified version to you if you'd rather)
* Send a large number (~15) of priority 0 messages to fill the queue
* Send some priority 9 messages, these should be processed before the other priority 0 messages, once a processing slot becomes free

