### PR TITLE
Bugfix: forgot to add priority info to end of run script

### DIFF
--- a/scripts/EndOfRunMonitor/Stomp_Client.py
+++ b/scripts/EndOfRunMonitor/Stomp_Client.py
@@ -41,6 +41,6 @@ class StompClient(object):
             self._connection.stop()
         self._connection = None
 
-    def send(self, destination, message, persistent='true'):
+    def send(self, destination, message, persistent='true', priority='4'):
         self.connect()
-        self._connection.send(destination, message, persistent=persistent)
+        self._connection.send(destination, message, persistent=persistent, priority=priority)


### PR DESCRIPTION
Found a small bug in EndOfRun script, queue priority was not being used.