### PR TITLE
Populate error logs from Mantid

### DIFF
--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -199,6 +199,7 @@ class PostProcessAdmin:
                 reduce_script = self.replace_variables(reduce_script)
                 out_directories = reduce_script.main(input_file=str(self.data_file), output_dir=str(reduce_result_dir))
             except Exception as e:
+                errFile.write(e)
                 self.copy_temp_directory(reduce_result_dir, reduce_result_dir_tail_length)
                 raise
             finally:

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -2,7 +2,7 @@
 """
 Post Process Administrator. It kicks off cataloging and reduction jobs.
 """
-import logging, json, socket, os, sys, subprocess, time, shutil, imp, stomp, re, errno
+import logging, json, socket, os, sys, time, shutil, imp, stomp, re, errno, traceback
 import logging.handlers
 
 logger = logging.getLogger(__name__)
@@ -199,8 +199,8 @@ class PostProcessAdmin:
                 reduce_script = self.replace_variables(reduce_script)
                 out_directories = reduce_script.main(input_file=str(self.data_file), output_dir=str(reduce_result_dir))
             except Exception as e:
-                with open(script_err) as f:
-                    f.write(str(e))
+                with open(script_err, "w") as f:
+                    f.write(traceback.print_exc())
                 self.copy_temp_directory(reduce_result_dir, reduce_result_dir_tail_length)
                 raise
             finally:

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -200,6 +200,7 @@ class PostProcessAdmin:
                 out_directories = reduce_script.main(input_file=str(self.data_file), output_dir=str(reduce_result_dir))
             except Exception as e:
                 with open(script_err, "w") as f:
+                    f.writelines(str(e) + "\n")
                     f.write(traceback.format_exc())
                 self.copy_temp_directory(reduce_result_dir, reduce_result_dir_tail_length)
                 raise

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -200,7 +200,7 @@ class PostProcessAdmin:
                 out_directories = reduce_script.main(input_file=str(self.data_file), output_dir=str(reduce_result_dir))
             except Exception as e:
                 with open(script_err, "w") as f:
-                    f.write(traceback.print_exc())
+                    f.write(traceback.format_exc())
                 self.copy_temp_directory(reduce_result_dir, reduce_result_dir_tail_length)
                 raise
             finally:


### PR DESCRIPTION
Fixes #144 

The stdout and stderr produced when running Mantid is now saved in various logs, as well as tracebacks when errors occur.

The Mantid stdout (what would be shown in the Mantid script window) is saved in reduction_log/RB#Run#Script.out

The Mantid stderr (what would be shown in the Mantid log window) is saved in reduction_log/RB#Run#Mantid.err

In the event of the script failing a python traceback is shown in RB#Run#Script.err

To test:
* Run a job and confirm that the expected outputs are given in the files listed above