### PR TITLE
Increased description length on re-runs to 200 chars

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -28,16 +28,16 @@ class Status(models.Model):
 class ReductionRun(models.Model):
     instrument = models.ForeignKey(Instrument, related_name='reduction_runs', null=True)
     run_number = models.IntegerField(blank=False)
-    run_name = models.CharField(max_length=50,blank=True)
+    run_name = models.CharField(max_length=200, blank=True)
     run_version = models.IntegerField(blank=False)
-    experiment = models.ForeignKey(Experiment,blank=False, related_name='reduction_runs')
-    created = models.DateTimeField(auto_now_add=True,blank=False)
+    experiment = models.ForeignKey(Experiment, blank=False, related_name='reduction_runs')
+    created = models.DateTimeField(auto_now_add=True, blank=False)
     started_by = models.IntegerField(null=True, blank=True)
-    last_updated = models.DateTimeField(auto_now=True,blank=False)
+    last_updated = models.DateTimeField(auto_now=True, blank=False)
     status = models.ForeignKey(Status, blank=False, related_name='+', default=1)
     started = models.DateTimeField(null=True, blank=True)
     finished = models.DateTimeField(null=True, blank=True)
-    message = models.CharField(max_length=255,blank=True)
+    message = models.CharField(max_length=255, blank=True)
     graph = SeparatedValuesField(null=True, blank=True)
 
     def __unicode__(self):

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -115,7 +115,7 @@
             validateNotEmpty.call(this);
         };
         var validateDescriptionText = function validateDescriptionText(){
-            var max_length = 50;
+            var max_length = 200;
             if($(this).val().length >= max_length) {
                 isValid = false;
                 errorMessages.push('Re-run description must be less than ' + max_length.toString() + ' characters.')


### PR DESCRIPTION
As requested re-run description lengths are now longer.

To test:
* Re run a job with a description between 50 and 200 characters, this should succeed
* Re run a job with a description over 200 characters, this should give a similar warning as before (not a 500 error page) 