### PR TITLE
Scripts can now be selected when re-running

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -83,7 +83,7 @@ class Listener(object):
         
         if created or reduction_run.status == StatusUtils().get_error():
             reduction_run.status = StatusUtils().get_queued()
-            variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+            variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, True)
             data_location = DataLocation(file_path=self._data_dict['data'], reduction_run=reduction_run)
 
             if not variables:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/tests.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/tests.py
@@ -233,7 +233,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=99999)
         reduction_run = ReductionRun(run_number=1, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")
@@ -255,7 +255,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=1)
         reduction_run = ReductionRun(run_number=100000, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")
@@ -269,7 +269,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=1)
         reduction_run = ReductionRun(run_number=123, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -204,19 +204,21 @@ class InstrumentVariablesUtils(object):
         """
         Reloads script in variables to match that on disk (inefficient)
         """
-        variable = variables[0]  # Assume script will be the same for all variables
+        variable = variables[0]  # Assume old script will be the same for all variables
+        instrument_name = variable.instrument.name
 
         script_cache_mod, script_vars_cache_mod = ScriptUtils().get_cache_scripts_modified(variable.scripts.all())
-        script_file_mod, script_vars_file_mod = self.__get_scripts_modified(variable.instrument.name)
+        script_file_mod, script_vars_file_mod = self.__get_scripts_modified(instrument_name)
 
         if script_cache_mod < script_file_mod:
             logger.info("Reduce.py script out of date, reloading")
-            script_binary = self.__load_reduction_script(variable.instrument.name)
+            script_binary = self.__load_reduction_script(instrument_name)
             self.__add_new_script_to_variables(variables, script_binary, 'reduce.py')
 
         if script_vars_cache_mod < script_vars_file_mod:
             logger.info("Reduce_vars.py script out of date, reloading")
-            reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(variable.instrument.name)
+            reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(instrument_name)
+            variables = self.get_default_variables(instrument_name, reduce_vars_script)
             self.__add_new_script_to_variables(variables, vars_script_binary, 'reduce_vars.py')
 
         return variables

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -250,9 +250,10 @@ class InstrumentVariablesUtils(object):
 
         return variables
 
-    def get_variables_for_run(self, reduction_run):
+    def get_variables_for_run(self, reduction_run, use_up_to_date):
         """
         Fetches the appropriate variables for the given reduction run.
+        If use_up_to_date is on the scripts that are currently on the server are used.
         If instrument variables with a matching experiment reference number is found then these will be used
         otherwise the variables with the closest run start will be used.
         If no variable are found, default variables are created for the instrument and those are returned.
@@ -266,7 +267,10 @@ class InstrumentVariablesUtils(object):
             except AttributeError:
                 # Still not found any variables, we better create some
                 variables = self.set_default_instrument_variables(reduction_run.instrument.name)
-        variables = self.__check_script_up_to_date(variables)  # For the moment reload script on all new runs
+
+        if use_up_to_date:
+            variables = self.__check_script_up_to_date(variables)
+
         return variables
 
     def get_current_script_text(self, instrument_name):

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -1,12 +1,11 @@
 import logging, os, sys, imp, uuid, re, json, time
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
-from autoreduce_webapp.settings import LOG_FILE, LOG_LEVEL, BASE_DIR, ACTIVEMQ, TEMP_OUTPUT_DIRECTORY, REDUCTION_DIRECTORY, FACILITY
+from autoreduce_webapp.settings import ACTIVEMQ, TEMP_OUTPUT_DIRECTORY, REDUCTION_DIRECTORY, FACILITY
 from autoreduce_webapp.queue_processor import Client as ActiveMQClient
 logger = logging.getLogger('django')
-from django.db import models
 from reduction_variables.models import InstrumentVariable, ScriptFile, RunVariable
-from reduction_viewer.models import ReductionRun, Instrument, Notification
+from reduction_viewer.models import ReductionRun, Notification
 from reduction_viewer.utils import InstrumentUtils, StatusUtils
 from autoreduce_webapp.icat_communication import ICATCommunication
 
@@ -309,7 +308,7 @@ class InstrumentVariablesUtils(object):
                     is_advanced=False, 
                     type=VariableUtils().get_type_string(reduce_script.standard_vars[key]),
                     start_run = 0,
-                    help_text=self.get_help_text('standard_vars', key, reduce_script),
+                    help_text=self.get_help_text('standard_vars', key, instrument_name, reduce_script),
                     )
                 variables.append(variable)
         if 'advanced_vars' in dir(reduce_script):
@@ -321,12 +320,12 @@ class InstrumentVariablesUtils(object):
                     is_advanced=True, 
                     type=VariableUtils().get_type_string(reduce_script.advanced_vars[key]),
                     start_run = 0,
-                    help_text=self.get_help_text('advanced_vars', key, reduce_script),
+                    help_text=self.get_help_text('advanced_vars', key, instrument_name, reduce_script),
                     )
                 variables.append(variable)
         return variables
 
-    def get_help_text(self, dictionary, key, reduce_script=None):
+    def get_help_text(self, dictionary, key, instrument_name, reduce_script=None):
         if not dictionary or not key:
             return ""
         if not reduce_script:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -197,6 +197,7 @@ class InstrumentVariablesUtils(object):
         script = ScriptFile(script=script_binary, file_name=script_name)
         script.save()
         for variable in variables:
+            variable.save()
             variable.scripts.add(script)
             variable.save()
 
@@ -210,16 +211,16 @@ class InstrumentVariablesUtils(object):
         script_cache_mod, script_vars_cache_mod = ScriptUtils().get_cache_scripts_modified(variable.scripts.all())
         script_file_mod, script_vars_file_mod = self.__get_scripts_modified(instrument_name)
 
-        if script_cache_mod < script_file_mod:
-            logger.info("Reduce.py script out of date, reloading")
-            script_binary = self.__load_reduction_script(instrument_name)
-            self.__add_new_script_to_variables(variables, script_binary, 'reduce.py')
-
         if script_vars_cache_mod < script_vars_file_mod:
             logger.info("Reduce_vars.py script out of date, reloading")
             reduce_vars_script, vars_script_binary = self.__load_reduction_vars_script(instrument_name)
             variables = self.get_default_variables(instrument_name, reduce_vars_script)
             self.__add_new_script_to_variables(variables, vars_script_binary, 'reduce_vars.py')
+
+        if script_cache_mod < script_file_mod:
+            logger.info("Reduce.py script out of date, reloading")
+            script_binary = self.__load_reduction_script(instrument_name)
+            self.__add_new_script_to_variables(variables, script_binary, 'reduce.py')
 
         return variables
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -448,13 +448,14 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         experiment_reference = request.POST.get('experiment_reference', None)
         start_run = request.POST.get('start_run', None)
         lookup_run_number = request.POST.get('run_number', None)
+        lookup_run_version = request.POST.get('run_version', None)
         use_current_script = request.POST.get('use_current_script', u"false").lower() == u"true"
         default_variables = None
         if not use_current_script:
             if lookup_run_number is not None:
                 try:
-                    run = ReductionRun.objects.get(run_number=lookup_run_number)
-                    default_variables = RunVariable.objects.filter(reduction_run=run)
+                    run = ReductionRun.objects.get(run_number=lookup_run_number, run_version=lookup_run_version)
+                    default_variables = RunVariable.objects.filter(reduction_run=run, )
                 except Exception as e:
                     logger.info("Run not found :" + str(e))
             else:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -31,10 +31,10 @@ def instrument_summary(request, instrument):
     for variables in upcoming_variables_by_run:
         if variables.start_run not in upcoming_variables_by_run_dict:
             upcoming_variables_by_run_dict[variables.start_run] = {
-                'run_start' : variables.start_run,
-                'run_end' : 0, # We'll fill this in after
-                'variables' : [],
-                'instrument' : instrument,
+                'run_start': variables.start_run,
+                'run_end': 0, # We'll fill this in after
+                'variables': [],
+                'instrument': instrument,
             }
         upcoming_variables_by_run_dict[variables.start_run]['variables'].append(variables)
 
@@ -44,8 +44,8 @@ def instrument_summary(request, instrument):
         upcoming_variables_by_run_ordered.append(upcoming_variables_by_run_dict[key])
     sorted(upcoming_variables_by_run_ordered, key=lambda r: r['run_start'])
     
-    # Fill in the run end nunmbers
-    run_end = 0;
+    # Fill in the run end numbers
+    run_end = 0
     for run_number in sorted(upcoming_variables_by_run_dict.iterkeys(), reverse=True):
         upcoming_variables_by_run_dict[run_number]['run_end'] = run_end
         run_end = run_number-1
@@ -56,10 +56,10 @@ def instrument_summary(request, instrument):
         next_variable_run_start = 1
     
     current_vars = {
-        'run_start' : current_variables[0].start_run,
-        'run_end' : next_variable_run_start-1,
-        'variables' : current_variables,
-        'instrument' : instrument,
+        'run_start': current_variables[0].start_run,
+        'run_end': next_variable_run_start-1,
+        'variables': current_variables,
+        'instrument': instrument,
     }
 
     # Create a nested dictionary for by-experiment
@@ -67,9 +67,9 @@ def instrument_summary(request, instrument):
     for variables in upcoming_variables_by_experiment:
         if variables.experiment_reference not in upcoming_variables_by_experiment_dict:
             upcoming_variables_by_experiment_dict[variables.experiment_reference] = {
-                'experiment' : variables.experiment_reference,
-                'variables' : [],
-                'instrument' : instrument,
+                'experiment': variables.experiment_reference,
+                'variables': [],
+                'instrument': instrument,
             }
         upcoming_variables_by_experiment_dict[variables.experiment_reference]['variables'].append(variables)
 
@@ -78,13 +78,12 @@ def instrument_summary(request, instrument):
     for key in sorted(upcoming_variables_by_experiment_dict):
         upcoming_variables_by_experiment_ordered.append(upcoming_variables_by_experiment_dict[key])
     sorted(upcoming_variables_by_experiment_ordered, key=lambda r: r['experiment'])
-    
 
     context_dictionary = {
-        'instrument' : instrument,
-        'current_variables' : current_vars,
-        'upcoming_variables_by_run' : upcoming_variables_by_run_ordered,
-        'upcoming_variables_by_experiment' : upcoming_variables_by_experiment_ordered,
+        'instrument': instrument,
+        'current_variables': current_vars,
+        'upcoming_variables_by_run': upcoming_variables_by_run_ordered,
+        'upcoming_variables_by_experiment': upcoming_variables_by_experiment_ordered,
     }
 
     return render_to_response('snippets/instrument_summary_variables.html', context_dictionary, RequestContext(request))
@@ -100,7 +99,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
     script = None
     script_vars = None
     if request.method == 'POST':
-        # Truthy value comes back as text so we'll compare it to a string of "True"
+        # Truth value comes back as text so we'll compare it to a string of "True"
         is_run_range = request.POST.get("variable-range-toggle-value", "True") == "True"
 
         if is_run_range:
@@ -111,7 +110,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
                 old_variables = InstrumentVariable.objects.filter(instrument=instrument, start_run=start)
                 script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
                 default_variables = list(old_variables)
-            if script == None or request.POST.get("is_editing", '') != 'True':
+            if script is None or request.POST.get("is_editing", '') != 'True':
                 script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
                 script = ScriptFile(script=script_binary, file_name='reduce.py')
                 script.save()
@@ -132,12 +131,11 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
         else:
             experiment_reference = request.POST.get("experiment_reference_number", 1)
 
-
             if request.POST.get("is_editing", '') == 'True':
                 old_variables = InstrumentVariable.objects.filter(instrument=instrument, experiment_reference=experiment_reference)
                 script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
                 default_variables = list(old_variables)
-            if script == None or request.POST.get("is_editing", '') != 'True':
+            if script is None or request.POST.get("is_editing", '') != 'True':
                 script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
                 script = ScriptFile(script=script_binary, file_name='reduce.py')
                 script.save()
@@ -182,18 +180,18 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 
         return redirect('instrument_summary', instrument=instrument.name)
     else:
-        editing = (start>0 or experiment_reference>0)
+        editing = (start > 0 or experiment_reference > 0)
         completed_status = StatusUtils().get_completed()
         processing_status = StatusUtils().get_processing()
         queued_status = StatusUtils().get_queued()
 
         try:
             latest_completed_run = ReductionRun.objects.filter(instrument=instrument, run_version=0, status=completed_status).order_by('-run_number').first().run_number
-        except AttributeError :
+        except AttributeError:
             latest_completed_run = 0
         try:
             latest_processing_run = ReductionRun.objects.filter(instrument=instrument, run_version=0, status=processing_status).order_by('-run_number').first().run_number
-        except AttributeError :
+        except AttributeError:
             latest_processing_run = 0
 
         if experiment_reference > 0:
@@ -213,7 +211,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
         if not editing:
             variables = InstrumentVariablesUtils().get_default_variables(instrument.name)
         elif not variables:
-            # If no variables are saved, use the dfault ones from the reduce script
+            # If no variables are saved, use the default ones from the reduce script
             editing = False
             InstrumentVariablesUtils().set_default_instrument_variables(instrument.name, start)
             variables = InstrumentVariable.objects.filter(instrument=instrument,start_run=start )
@@ -272,16 +270,6 @@ def run_summary(request, run_number, run_version=0):
             advanced_vars[variable.name] = variable
         else:
             standard_vars[variable.name] = variable
-
-    # Commented out as no button to update to Instrument specified variables yet
-    # default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
-    # default_standard_variables = {}
-    # default_advanced_variables = {}
-    # for variable in default_variables:
-    #     if variable.is_advanced:
-    #         default_advanced_variables[variable.name] = variable
-    #     else:
-    #         default_standard_variables[variable.name] = variable
 
     current_variables = InstrumentVariablesUtils().get_default_variables(reduction_run.instrument.name)
     current_standard_variables = {}
@@ -348,32 +336,23 @@ def run_confirmation(request, run_number, run_version=0):
 
         for key,value in request.POST.iteritems():
             if 'var-' in key:
+                name = None
                 if 'var-advanced-' in key:
-                    name = key.replace('var-advanced-', '').replace('-',' ')
-                    default_var = next((x for x in run_variables if x.name == name), next((x for x in default_variables if x.name == name), None))
-                    if not default_var: continue
-                    variable = RunVariable(
-                        reduction_run=new_job,
-                        name=default_var.name, 
-                        value=value, 
-                        is_advanced=True, 
-                        type=default_var.type,
-                        help_text=default_var.help_text
-                    )
-                    variable.save()
-                    variable.scripts.add(script)
-                    variable.scripts.add(script_vars)
-                    variable.save()
-                    new_variables.append(variable)
+                    name = key.replace('var-advanced-', '').replace('-', ' ')
+                    is_advanced = True
                 if 'var-standard-' in key:
-                    name = key.replace('var-standard-', '').replace('-',' ')
+                    name = key.replace('var-standard-', '').replace('-', ' ')
+                    is_advanced = False
+                    
+                if name is not None:
                     default_var = next((x for x in run_variables if x.name == name), next((x for x in default_variables if x.name == name), None))
-                    if not default_var: continue
+                    if not default_var:
+                        continue
                     variable = RunVariable(
                         reduction_run=new_job,
-                        name=default_var.name, 
-                        value=value, 
-                        is_advanced=False, 
+                        name=default_var.name,
+                        value=value,
+                        is_advanced=is_advanced,
                         type=default_var.type,
                         help_text=default_var.help_text
                     )
@@ -382,36 +361,31 @@ def run_confirmation(request, run_number, run_version=0):
                     variable.scripts.add(script_vars)
                     variable.save()
                     new_variables.append(variable)
-        
+
+        queue_count = ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count()
+
+        context_dictionary = {
+            'run' : None,
+            'variables' : None,
+            'queued' : queue_count,
+        }
+
         if len(new_variables) == 0:
             new_job.delete()
             script.delete()
             script_vars.delete()
-            context_dictionary = {
-                'run' : None,
-                'variables' : None,
-                'queued' : ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count(),
-                'error' : 'No variables were found to be submitted.'
-            }
+            context_dictionary['error'] = 'No variables were found to be submitted.'
         else:
             try:
                 MessagingUtils().send_pending(new_job)
-                context_dictionary = {
-                    'run' : new_job,
-                    'variables' : new_variables,
-                    'queued' : ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count(),
-                }
+                context_dictionary['run'] = new_job
+                context_dictionary['variables'] = new_variables
             except Exception, e:
                 new_job.delete()
                 script.delete()
                 script_vars.delete()
-                context_dictionary = {
-                    'run' : None,
-                    'variables' : None,
-                    'queued' : ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count(),
-                    'error' : 'Failed to send new job. (%s)' % str(e),
-                }
-        
+                context_dictionary['error'] = 'Failed to send new job. (%s)' % str(e),
+
         return context_dictionary
     else:
         return redirect('instrument_summary', instrument=instrument.name)
@@ -481,21 +455,26 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
 
         for key,value in request.POST.iteritems():
             if 'var-' in key:
+                pattern = None
                 if 'var-advanced-' in key:
                     name = key.replace('var-advanced-', '').replace('-',' ')
                     default_var = next((x for x in default_variables if x.name == name), None)
-                    if not default_var: continue
+                    if not default_var:
+                        continue
                     pattern = advanced_pattern % name
 
                 if 'var-standard-' in key:
                     name = key.replace('var-standard-', '').replace('-',' ')
                     default_var = next((x for x in default_variables if x.name == name), None)
-                    if not default_var: continue
+                    if not default_var:
+                        continue
                     pattern = standard_pattern % name
-                # Wrap the value in the correct syntax to indicate the type
-                value = VariableUtils().wrap_in_type_syntax(value, default_var.type)
-                value = '\g<before>%s' % value
-                script_vars_file = re.sub(pattern, value, script_vars_file)
+
+                if pattern is not None:
+                    # Wrap the value in the correct syntax to indicate the type
+                    value = VariableUtils().wrap_in_type_syntax(value, default_var.type)
+                    value = '\g<before>%s' % value
+                    script_vars_file = re.sub(pattern, value, script_vars_file)
 
     reduce_script += script_vars_file
     reduce_script += '\n\n"""\nreduce.py\n"""\n\n'

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -1,16 +1,15 @@
-from django.shortcuts import render,redirect
+from django.shortcuts import redirect
 from django.core.context_processors import csrf
 from django.template import RequestContext
 from django.shortcuts import render_to_response
-from django.views.generic.base import View
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_staff
 from reduction_variables.models import InstrumentVariable, RunVariable, ScriptFile
 from reduction_variables.utils import InstrumentVariablesUtils, VariableUtils, MessagingUtils, ScriptUtils
 from reduction_viewer.models import Instrument, ReductionRun, DataLocation
 from reduction_viewer.utils import StatusUtils
-from autoreduce_webapp.icat_communication import ICATCommunication
-from autoreduce_webapp.settings import LOG_FILE, LOG_LEVEL
+
 import logging, re
 logger = logging.getLogger(__name__)
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -274,7 +274,7 @@ def run_summary(request, run_number, run_version=0):
         else:
             standard_vars[variable.name] = variable
 
-    default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+    default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
     default_standard_variables = {}
     default_advanced_variables = {}
     for variable in default_variables:
@@ -337,7 +337,7 @@ def run_confirmation(request, run_number, run_version=0):
         script_vars.save()
 
         run_variables = reduction_run.run_variables.all()
-        default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
+        default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
         new_variables = []
 
         for key,value in request.POST.iteritems():

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -274,14 +274,15 @@ def run_summary(request, run_number, run_version=0):
         else:
             standard_vars[variable.name] = variable
 
-    default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
-    default_standard_variables = {}
-    default_advanced_variables = {}
-    for variable in default_variables:
-        if variable.is_advanced:
-            default_advanced_variables[variable.name] = variable
-        else:
-            default_standard_variables[variable.name] = variable
+    # Commented out as no button to update to Instrument specified variables yet
+    # default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
+    # default_standard_variables = {}
+    # default_advanced_variables = {}
+    # for variable in default_variables:
+    #     if variable.is_advanced:
+    #         default_advanced_variables[variable.name] = variable
+    #     else:
+    #         default_standard_variables[variable.name] = variable
 
     current_variables = InstrumentVariablesUtils().get_default_variables(reduction_run.instrument.name)
     current_standard_variables = {}
@@ -297,8 +298,8 @@ def run_summary(request, run_number, run_version=0):
         'run_version' : run_version,
         'standard_variables' : standard_vars,
         'advanced_variables' : advanced_vars,
-        'default_standard_variables' : default_standard_variables,
-        'default_advanced_variables' : default_advanced_variables,
+        'default_standard_variables' : standard_vars,
+        'default_advanced_variables' : advanced_vars,
         'current_standard_variables' : current_standard_variables,
         'current_advanced_variables' : current_advanced_variables,
         'instrument' : reduction_run.instrument,

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -1,5 +1,6 @@
 (function(){
     var formUrl = $('#run_variables').attr('action');
+    var use_current_script = false;
 
     var previewScript = function previewScript(event){
         var submitAction = function submitAction(){
@@ -235,6 +236,8 @@
             var $form = $('#run_variables');
             if($form.length===0) $form = $('#instrument_variables');
             $form.attr('action', formUrl);
+            $form.createElement("use_current_script");
+            $form.elements["use_current_script"].value = use_current_script;
             window.onbeforeunload = undefined;
             $form.submit();
         };

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -1,6 +1,5 @@
 (function(){
     var formUrl = $('#run_variables').attr('action');
-    var use_current_script = false;
 
     var previewScript = function previewScript(event){
         var submitAction = function submitAction(){
@@ -236,8 +235,6 @@
             var $form = $('#run_variables');
             if($form.length===0) $form = $('#instrument_variables');
             $form.attr('action', formUrl);
-            $form.createElement("use_current_script");
-            $form.elements["use_current_script"].value = use_current_script;
             window.onbeforeunload = undefined;
             $form.submit();
         };
@@ -296,6 +293,7 @@
         var $form = $('#run_variables');
         if($form.length===0) $form = $('#instrument_variables');
         $form.find('.js-variables-container').html($('.js-default-variables').html());
+        $('#use_current_script').val("false");
         // We need to enable the popover again as the element is new
         $('[data-toggle="popover"]').popover();
     };
@@ -305,6 +303,7 @@
         var $form = $('#run_variables');
         if($form.length===0) $form = $('#instrument_variables');
         $form.find('.js-variables-container').html($('.js-current-variables').html());
+        $('#use_current_script').val("true");
         // We need to enable the popover again as the element is new
         $('[data-toggle="popover"]').popover();
     };

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
@@ -5,6 +5,7 @@
     <div class="panel-body collapse" id="rerun_form">
         <form id="run_variables" method="POST" action="{% url 'run_confirmation' run_number=run_number run_version=run_version %}" class="form-horizontal">
             {% csrf_token %}
+            <input type="hidden" name="use_current_script" id="use_current_script" value="false">
             <div class="row">
                 <div class="col-md-9">
                     {% include "snippets/form_warnings.html" %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
@@ -6,6 +6,7 @@
         <form id="run_variables" method="POST" action="{% url 'run_confirmation' run_number=run_number run_version=run_version %}" class="form-horizontal">
             {% csrf_token %}
             <input type="hidden" name="use_current_script" id="use_current_script" value="false">
+            <input type="hidden" name="run_number" value="{{ run_number }} ">
             <div class="row">
                 <div class="col-md-9">
                     {% include "snippets/form_warnings.html" %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
@@ -7,6 +7,7 @@
             {% csrf_token %}
             <input type="hidden" name="use_current_script" id="use_current_script" value="false">
             <input type="hidden" name="run_number" value="{{ run_number }} ">
+            <input type="hidden" name="run_version" value="{{ run_version }} ">
             <div class="row">
                 <div class="col-md-9">
                     {% include "snippets/form_warnings.html" %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
@@ -36,12 +36,12 @@
                                     <div class="js-explaination visible-xs-block">Download the reduction script with the selected variables inserted.</div>
                                 </li>
                                 <li>
-                                    <a href="#resetValues" id="resetValues">Reset to default values</a>
-                                    <div class="js-explaination visible-xs-block">Reset all variable values to those set in the script.</div>
+                                    <a href="#resetValues" id="resetValues">Reset to original script and values</a>
+                                    <div class="js-explaination visible-xs-block">Reset to the script and variables previously specified for the run.</div>
                                 </li>
                                 <li>
                                     <a href="#currentScript" id="currentScript">Reset to current script and values</a>
-                                    <div class="js-explaination visible-xs-block">Ignore the script specified for the run and use the current script and variables.</div>
+                                    <div class="js-explaination visible-xs-block">Reset to use the current script and the default variables that ot contains.</div>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
Fixes #173 

This fixes unusual behaviour surrounding which scripts re-runs use.

To test:
* Send a run to autoreduce, wait to finish
* Modify the corresponding reduce.py and reduce_vars.py script
* Open the run previously sent on the WebApp, confirm that the 'Preview Script' shows the old script
* Make some variable changes and submit the re-run
* Confirm the old script is used but with updated variables
* Open the run again, click reset to current script
* Confirm that modifications made in reduce_vars are shown in the corresponding textboxes
* Confirm that the 'Preview Script' shows the new script
* Make some variable changes and submit the re-run
* Confirm the new script is used with updated variables

When testing this ticket be aware of issue #184