### PR TITLE
remove top level run reduction error notifications. re #189

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -164,27 +164,6 @@ def run_list(request):
         instrument_obj['runs'] = sorted(instrument_obj['runs'], key=operator.attrgetter('last_updated'), reverse=True)
         instrument_obj['experiments'] = sorted(instrument_obj['experiments'], key=lambda k: k['reference_number'], reverse=True)
         instruments.append(instrument_obj)
-    
-    # Generate notification for any errored runs    
-    error_runs = ReductionRun.objects.filter(status=StatusUtils().get_error())
-    if error_runs:
-        notifications = []
-        for run in error_runs:
-            if run.run_name:
-                message = 'Reduction run %s-%s has reported an error.' % (run.run_number, run.run_name)
-            elif run.run_version > 0:
-                message = 'Reduction run %s-%s has reported an error.' % (run.run_number, run.run_version)
-            else:
-                message = 'Reduction run %s has reported an error.' % run.run_number
-            error_notification = {
-                'message': message,
-                'severity_verbose': 'error',
-                'is_staff_only': False,
-                'is_active': True,
-                'id' : 'error-%s-%s' % (run.run_number, run.run_version),
-            }
-            notifications.append(error_notification)
-        context_dictionary['notifications'] = notifications
 
     context_dictionary['instrument_list'] = instruments
     if owned_instruments:


### PR DESCRIPTION
Fixes #189 

To test:

* check that all top level run specific reduction notifications are no longer displayed on webapp
* submit a job to check that the webapp is working