### PR TITLE
Correct behaviour of future run variables

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -83,7 +83,7 @@ class Listener(object):
         
         if created or reduction_run.status == StatusUtils().get_error():
             reduction_run.status = StatusUtils().get_queued()
-            variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, True)
+            variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
             data_location = DataLocation(file_path=self._data_dict['data'], reduction_run=reduction_run)
 
             if not variables:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/models.py
@@ -18,6 +18,7 @@ class InstrumentVariable(models.Model):
     type = models.CharField(max_length=50, blank=False)
     is_advanced = models.BooleanField(default=False)
     scripts = models.ManyToManyField(ScriptFile)
+    tracks_script = models.BooleanField(default=True)
     help_text = models.CharField(max_length=300, blank=True, null=True, default='')
 
     def __unicode__(self):

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/tests.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/tests.py
@@ -233,7 +233,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=99999)
         reduction_run = ReductionRun(run_number=1, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")
@@ -255,7 +255,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=1)
         reduction_run = ReductionRun(run_number=100000, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")
@@ -269,7 +269,7 @@ class InstrumentVariablesUtilsTestCase(TestCase):
         experiment = Experiment(reference_number=1)
         reduction_run = ReductionRun(run_number=123, instrument=instrument, experiment=experiment, run_version=1, status=StatusUtils().get_queued())
 
-        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, False)
+        variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run)
 
         self.assertNotEqual(variables, None, "Expecting some variables to be returned")
         self.assertNotEqual(variables, [], "Expecting some variables to be returned")

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -200,7 +200,7 @@ class InstrumentVariablesUtils(object):
             variable.scripts.add(script)
             variable.save()
 
-    def __get_variables_from_script(self, instrument_name):
+    def get_variables_from_current_script(self, instrument_name):
         """
         Reloads script in variables to match that on disk. For now ignore modification time check.
         """
@@ -240,17 +240,18 @@ class InstrumentVariablesUtils(object):
 
         return variables
 
-    def get_variables_for_run(self, reduction_run, use_up_to_date):
+    def get_variables_for_run(self, reduction_run, check_script_tracking):
         """
         Fetches the appropriate variables for the given reduction run.
-        If use_up_to_date is on the scripts that are currently on the server are used.
         If instrument variables with a matching experiment reference number is found then these will be used
         otherwise the variables with the closest run start will be used.
+        If check_script_tracking is on the track_changes field of the instrument variables is used and so scripts that
+        are currently on the instrument may be used.
         If no variable are found, default variables are created for the instrument and those are returned.
         """
         instrument_name = reduction_run.instrument.name
-        if use_up_to_date:
-            variables = self.__get_variables_from_script(instrument_name)
+        if check_script_tracking:
+            variables = self.get_variables_from_current_script(instrument_name)
         else:
             variables = InstrumentVariable.objects.filter(instrument=reduction_run.instrument, experiment_reference=reduction_run.experiment.reference_number)
             # No experiment-specific variables, lets look for run number

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -385,7 +385,7 @@ class ReductionVariablesUtils(object):
                 if reduction_run != variables.reduction_run.id:
                     raise Exception("All run variables must be for the same reduction run")
         
-        script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts(run_variables[0].scripts.all())
+        script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts_binary(run_variables[0].scripts.all())
 
         script_path = write_script_to_temp(script_binary, script_vars_binary)
 
@@ -435,14 +435,18 @@ class MessagingUtils(object):
 
 class ScriptUtils(object):
     def get_reduce_scripts(self, scripts):
-        script_binary = None
-        script_vars_binary = None
+        script_out = None
+        script_vars_out = None
         for script in scripts:
             if script.file_name == "reduce.py":
-                script_binary = script.script
+                script_out = script
             elif script.file_name == "reduce_vars.py":
-                script_vars_binary = script.script
-        return script_binary, script_vars_binary
+                script_vars_out = script
+        return script_out, script_vars_out
+
+    def get_reduce_scripts_binary(self, scripts):
+        script, script_vars = self.get_reduce_scripts(scripts)
+        return script.script, script_vars.script
 
     def get_cache_scripts_modified(self, scripts):
         """

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -22,7 +22,6 @@ def instrument_summary(request, instrument):
         raise PermissionDenied()
 
     instrument = Instrument.objects.get(name=instrument)
-    completed_status = StatusUtils().get_completed()
     
     current_variables, upcoming_variables_by_run, upcoming_variables_by_experiment = InstrumentVariablesUtils().get_current_and_upcoming_variables(instrument.name)
 
@@ -332,15 +331,16 @@ def run_confirmation(request, run_number, run_version=0):
 
         if use_current_script:
             script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
+            default_variables = InstrumentVariablesUtils().get_variables_from_current_script(reduction_run.instrument.name)
         else:
             script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts_binary(run_variables[0].scripts.all())
+            default_variables = run_variables
 
         script = ScriptFile(script=script_binary, file_name='reduce.py')
         script.save()
         script_vars = ScriptFile(script=script_vars_binary, file_name='reduce_vars.py')
         script_vars.save()
 
-        default_variables = InstrumentVariablesUtils().get_variables_for_run(reduction_run, use_current_script)
         new_variables = []
 
         for key,value in request.POST.iteritems():

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -102,6 +102,8 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
         # Truth value comes back as text so we'll compare it to a string of "True"
         is_run_range = request.POST.get("variable-range-toggle-value", "True") == "True"
 
+        track_scripts = request.POST.get("track_script_checkbox") == "on"
+
         if is_run_range:
             start = request.POST.get("run_start", 1)
             end = request.POST.get("run_end", None)
@@ -165,6 +167,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
                     value=post_variable, 
                     is_advanced=default_var.is_advanced, 
                     type=default_var.type,
+                    tracks_script=track_scripts,
                     )
                 if is_run_range:
                     variable.start_run = start

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -108,8 +108,9 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 
             if request.POST.get("is_editing", '') == 'True':
                 old_variables = InstrumentVariable.objects.filter(instrument=instrument, start_run=start)
-                script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
-                default_variables = list(old_variables)
+                if old_variables:
+                    script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
+                    default_variables = list(old_variables)
             if script is None or request.POST.get("is_editing", '') != 'True':
                 script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
                 script = ScriptFile(script=script_binary, file_name='reduce.py')
@@ -133,8 +134,9 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 
             if request.POST.get("is_editing", '') == 'True':
                 old_variables = InstrumentVariable.objects.filter(instrument=instrument, experiment_reference=experiment_reference)
-                script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
-                default_variables = list(old_variables)
+                if old_variables:
+                    script, script_vars = ScriptUtils().get_reduce_scripts(old_variables[0].scripts.all())
+                    default_variables = list(old_variables)
             if script is None or request.POST.get("is_editing", '') != 'True':
                 script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
                 script = ScriptFile(script=script_binary, file_name='reduce.py')
@@ -325,7 +327,7 @@ def run_confirmation(request, run_number, run_version=0):
         if use_current_script:
             script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
         else:
-            script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts(run_variables[0].scripts.all())
+            script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts_binary(run_variables[0].scripts.all())
 
         script = ScriptFile(script=script_binary, file_name='reduce.py')
         script.save()
@@ -411,7 +413,7 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
             run_variables = InstrumentVariable.objects.filter(experiment_reference=experiment_reference, instrument=instrument)
         else:
             run_variables = InstrumentVariable.objects.filter(start_run=run_number, instrument=instrument)
-        script, script_vars = ScriptUtils().get_reduce_scripts(run_variables[0].scripts.all())
+        script, script_vars = ScriptUtils().get_reduce_scripts_binary(run_variables[0].scripts.all())
         script_file = script.decode("utf-8")
         script_vars_file = script_vars.decode("utf-8")
 
@@ -446,7 +448,7 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
                     default_variables = InstrumentVariable.objects.filter(start_run=start_run, instrument=instrument)
 
         if default_variables:
-            script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts(default_variables[0].scripts.all())
+            script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts_binary(default_variables[0].scripts.all())
         else:
             script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument)
             default_variables = InstrumentVariablesUtils().get_default_variables(instrument)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -257,6 +257,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
             'minimum_run_start' : max(latest_completed_run, latest_processing_run),
             'upcoming_run_variables' : upcoming_run_variables,
             'editing' : editing,
+            'tracks_script' : variables[0].tracks_script,
         }
         context_dictionary.update(csrf(request))
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -33,6 +33,7 @@ def instrument_summary(request, instrument):
             upcoming_variables_by_run_dict[variables.start_run] = {
                 'run_start': variables.start_run,
                 'run_end': 0, # We'll fill this in after
+                'tracks_script': variables.tracks_script,
                 'variables': [],
                 'instrument': instrument,
             }
@@ -58,6 +59,7 @@ def instrument_summary(request, instrument):
     current_vars = {
         'run_start': current_variables[0].start_run,
         'run_end': next_variable_run_start-1,
+        'tracks_script': current_variables[0].tracks_script,
         'variables': current_variables,
         'instrument': instrument,
     }

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -1,5 +1,9 @@
 (function(){
-    var formUrl = $('#run_variables').attr('action');
+    if ($('#run_variables').length == 0) {
+        var originalFormUrl = $('#instrument_variables').attr('action');
+    }else {
+        var originalFormUrl = $('#run_variables').attr('action');
+    }
 
     var previewScript = function previewScript(event){
         var submitAction = function submitAction(){
@@ -233,11 +237,9 @@
     var submitForm = function submitForm(event){
         var submitAction = function submitAction(){
             var $form = $('#run_variables');
-            if($form.length===0) {
-                $form = $('#instrument_variables');
-            } else {
-                $form.attr('action', formUrl);
-            }
+            if($form.length===0) $form = $('#instrument_variables');
+
+            $form.attr('action', originalFormUrl);
             window.onbeforeunload = undefined;
             $form.submit();
         };

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -233,8 +233,11 @@
     var submitForm = function submitForm(event){
         var submitAction = function submitAction(){
             var $form = $('#run_variables');
-            if($form.length===0) $form = $('#instrument_variables');
-            $form.attr('action', formUrl);
+            if($form.length===0) {
+                $form = $('#instrument_variables');
+            } else {
+                $form.attr('action', formUrl);
+            }
             window.onbeforeunload = undefined;
             $form.submit();
         };

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -308,6 +308,11 @@
         $('[data-toggle="popover"]').popover();
     };
 
+    var toggleTrackScript = function toggleTrackScript(event) {
+        var checkBox = $('#track_script_checkbox');
+        checkBox.prop("checked", !checkBox.prop("checked"));
+    };
+
     var cancelForm = function cancelForm(event){
         event.preventDefault();
         window.onbeforeunload = undefined;
@@ -372,6 +377,8 @@
         $('#run_variables,#instrument_variables').on('click', '#variableSubmit', submitForm);
         $('#run_variables,#instrument_variables').on('click', '#cancelForm', cancelForm);
         $('#run_variables,#instrument_variables').on('click', 'input[type=checkbox][data-type=boolean]', updateBoolean);
+        $('#instrument_variables').on('click', '#track_script', toggleTrackScript);
+        $('#instrument_variables').on('mouseover mouseleave', '#track_script', toggleActionExplainations);
         $('.js-form-actions li>a').on('mouseover mouseleave', toggleActionExplainations);
         $('#run_end').on('change', triggerAfterRunOptions);
         $('.js-show-default-variables').on('click', showDefaultSriptVariables);

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -296,7 +296,10 @@
     var resetDefaultVariables = function resetDefaultVariables(event){
         event.preventDefault();
         var $form = $('#run_variables');
-        if($form.length===0) $form = $('#instrument_variables');
+        if($form.length===0){
+            $("#is_editing").val("false") //Set this so new reduce_vars are picked up from script
+            $form = $('#instrument_variables');
+        }
         $form.find('.js-variables-container').html($('.js-default-variables').html());
         $('#use_current_script').val("false");
         // We need to enable the popover again as the element is new

--- a/WebApp/ISIS/autoreduce_webapp/templates/help.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/help.html
@@ -79,6 +79,19 @@
             {% endif %}
         <div>
     </section>
+    <section class="help-topic panel panel-default" data-topics="reduction data file location directory output reduced">
+        <div class="panel-heading">
+            <h4>I've modified my reduction scripts, why aren't my new runs using it?</h4>
+        </div>
+        <div class="panel-body">
+            <p>
+                To make sure that reductions coming straight from the machine use new reduce.py scripts automatically go to the Upcoming Configurations page, click 'edit variables' in the currently used variables box and then ensure the 'Track script changes' checkbox is ticked. For runs that are being re-run click the 'Reset to current script and values' link under Additional Actions when re-running.
+            </p>
+            <p>
+                To update instrument variables to new ones entered into the reduce_vars.py script go to the Edit Future Configuration page and click 'Reset to default values', this must be done any time reduce_vars.py is modified.
+            </p>
+        <div>
+    </section>
     {% if request.user.is_staff %}
         <section class="help-topic panel panel-default" data-topics="script compatible work">
             <div class="panel-heading">

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -97,7 +97,7 @@
                                     </li>
                                     <li>
                                         <a href="#resetValues" id="resetValues">Reset to default values</a>
-                                        <div class="js-explaination visible-xs-block">Reset all variable values to those set in the script.</div>
+                                        <div class="js-explaination visible-xs-block">Reset all variables to those set in the script. This will pick up any changes made to the reduce_vars.py script.</div>
                                     </li>
                                     <div>
                                         <input type="checkbox" name="track_script_checkbox" id="track_script_checkbox" {% if tracks_script %}checked{% endif %}>

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -99,6 +99,11 @@
                                         <a href="#resetValues" id="resetValues">Reset to default values</a>
                                         <div class="js-explaination visible-xs-block">Reset all variable values to those set in the script.</div>
                                     </li>
+                                    <div>
+                                        <input type="checkbox" name="track_script_checkbox" id="track_script_checkbox">
+                                        <a href="#track_script" id="track_script"> Track script changes</a>
+                                        <div class="js-explaination visible-xs-block">Check this box to ensure that the reduce.py script used for these variables is always up to date with the one on the instrument</div>
+                                    </div>
                                 </ul>
                             </div>
                         </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -100,7 +100,7 @@
                                         <div class="js-explaination visible-xs-block">Reset all variable values to those set in the script.</div>
                                     </li>
                                     <div>
-                                        <input type="checkbox" name="track_script_checkbox" id="track_script_checkbox">
+                                        <input type="checkbox" name="track_script_checkbox" id="track_script_checkbox" {% if tracks_script %}checked{% endif %}>
                                         <a href="#track_script" id="track_script"> Track script changes</a>
                                         <div class="js-explaination visible-xs-block">Check this box to ensure that the reduce.py script used for these variables is always up to date with the one on the instrument</div>
                                     </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/variables.html
@@ -26,6 +26,10 @@
                     {% endif %}
                 </div>
             </div>
+            {% if instrument_variables.tracks_script %}
+            <small>(Tracking script changes)</small>
+            <br/>
+            {% endif %}
             <a href="{% url 'preview_script' instrument=instrument.name run_number=instrument_variables.run_start %}">preview reduction script</a>
             <br/>
             <a href="{% url 'instrument_variables' instrument=instrument.name start=instrument_variables.run_start end=instrument_variables.run_end %}">edit variables</a>


### PR DESCRIPTION
Fixes #186, fixes #187 

This ticket fixes a lot of issues with using Instrument Variables and how they are updated with changes in scripts. There is now a checkbox for every set of instrument variables that says whether the reduce.py script is updated with each new triggered run.

To Test:
* Create some instrument variables with track changes selected
* Confirm that the preview script is the current script, both on the editing page and the instrument summary page. A note should also show that changes are being tracked on the instrument summary page.
* Edit the reduce.py script and confirm that changes are made in previews and that a newly triggered run picks up changes.
* Turn off the track changes script and edit the script, confirming that changes are not updated in previews and not picked up on triggered runs
* For now reduce_vars.py changes are only picked up when the reset to default button is pressed in the edit instrument variables. Confirm that this is the case and that it sufficiently well documented