### PR TITLE
Reset to current variables now updates the form

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -20,7 +20,9 @@ urlpatterns = patterns('',
 
     url(r'^instrument/(?P<instrument>\w+)/$', reduction_viewer_views.instrument_summary, name='instrument_summary'),       
     url(r'^instrument/(?P<instrument>\w+)/variables(?:/(?P<start>[0-9]+))?(?:/(?P<end>[0-9]+))?/$', reduction_variables_views.instrument_variables, name='instrument_variables'),       
-    url(r'^instrument/(?P<instrument>\w+)/variables/experiment/(?P<experiment_reference>[0-9]+)/$', reduction_variables_views.instrument_variables, name='instrument_variables_by_experiment'),       
+    url(r'^instrument/(?P<instrument>\w+)/variables/experiment/(?P<experiment_reference>[0-9]+)/$', reduction_variables_views.instrument_variables, name='instrument_variables_by_experiment'),
+
+    url(r'^instrument/(?P<instrument>\w+)/default_variables/$', reduction_variables_views.current_default_variables, name='current_default_variables'),
 
     url(r'^experiment/(?P<reference_number>[0-9]+)/$', reduction_viewer_views.experiment_summary, name='experiment_summary'),       
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -9,7 +9,6 @@ from reduction_variables.models import InstrumentVariable, RunVariable, ScriptFi
 from reduction_variables.utils import InstrumentVariablesUtils, VariableUtils, MessagingUtils, ScriptUtils
 from reduction_viewer.models import Instrument, ReductionRun, DataLocation
 from reduction_viewer.utils import StatusUtils
-import json
 
 import logging, re
 logger = logging.getLogger(__name__)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -9,6 +9,7 @@ from reduction_variables.models import InstrumentVariable, RunVariable, ScriptFi
 from reduction_variables.utils import InstrumentVariablesUtils, VariableUtils, MessagingUtils, ScriptUtils
 from reduction_viewer.models import Instrument, ReductionRun, DataLocation
 from reduction_viewer.utils import StatusUtils
+import json
 
 import logging, re
 logger = logging.getLogger(__name__)
@@ -263,6 +264,25 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
         context_dictionary.update(csrf(request))
 
         return context_dictionary
+
+@require_staff
+@render_with('snippets/edit_variables.html')
+def current_default_variables(request, instrument):
+    variables = InstrumentVariablesUtils().get_default_variables(instrument)
+    standard_vars = {}
+    advanced_vars = {}
+    for variable in variables:
+        if variable.is_advanced:
+            advanced_vars[variable.name] = variable
+        else:
+            standard_vars[variable.name] = variable
+    context_dictionary = {
+        'instrument' : instrument,
+        'standard_variables' : standard_vars,
+        'advanced_variables' : advanced_vars,
+    }
+    context_dictionary.update(csrf(request))
+    return context_dictionary
 
 '''
     Imported into another view, thus no middlewear

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -297,10 +297,15 @@
         event.preventDefault();
         var $form = $('#run_variables');
         if($form.length===0){
-            $("#is_editing").val("false") //Set this so new reduce_vars are picked up from script
             $form = $('#instrument_variables');
+            //Get any new variables
+            $.get($('#updateURL').val(), function( data ) {
+                $form.find('.js-variables-container').html(data);
+            });
+            $("#is_editing").val("false"); //Set this so new reduce_vars are picked up from script
+        }else {
+            $form.find('.js-variables-container').html($('.js-default-variables').html());
         }
-        $form.find('.js-variables-container').html($('.js-default-variables').html());
         $('#use_current_script').val("false");
         // We need to enable the popover again as the element is new
         $('[data-toggle="popover"]').popover();

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -296,16 +296,9 @@
     var resetDefaultVariables = function resetDefaultVariables(event){
         event.preventDefault();
         var $form = $('#run_variables');
-        if($form.length===0){
+        if($form.length===0)
             $form = $('#instrument_variables');
-            //Get any new variables
-            $.get($('#updateURL').val(), function( data ) {
-                $form.find('.js-variables-container').html(data);
-            });
-            $("#is_editing").val("false"); //Set this so new reduce_vars are picked up from script
-        }else {
-            $form.find('.js-variables-container').html($('.js-default-variables').html());
-        }
+        $form.find('.js-variables-container').html($('.js-default-variables').html());
         $('#use_current_script').val("false");
         // We need to enable the popover again as the element is new
         $('[data-toggle="popover"]').popover();
@@ -314,8 +307,14 @@
     var resetCurrentVariables = function resetCurrentVariables(event){
         event.preventDefault();
         var $form = $('#run_variables');
-        if($form.length===0) $form = $('#instrument_variables');
-        $form.find('.js-variables-container').html($('.js-current-variables').html());
+        if($form.length===0) {
+            $form = $('#instrument_variables');
+            $("#is_editing").val("false"); //Set this so new reduce_vars are picked up from script
+        }
+        //Update variables to those in reduce_vars
+        $.get($('#updateURL').val(), function( data ) {
+            $form.find('.js-variables-container').html(data);
+        });
         $('#use_current_script').val("true");
         // We need to enable the popover again as the element is new
         $('[data-toggle="popover"]').popover();

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -307,13 +307,20 @@
     var resetCurrentVariables = function resetCurrentVariables(event){
         event.preventDefault();
         var $form = $('#run_variables');
+        //Set cursor to waiting
+        $("body").css("cursor", "wait");
+        $("#currentScript").css("cursor", "wait");
+
         if($form.length===0) {
             $form = $('#instrument_variables');
             $("#is_editing").val("false"); //Set this so new reduce_vars are picked up from script
         }
+
         //Update variables to those in reduce_vars
         $.get($('#updateURL').val(), function( data ) {
             $form.find('.js-variables-container').html(data);
+            $("body").css("cursor", "default");
+            $("#currentScript").css("cursor", "pointer");
         });
         $('#use_current_script').val("true");
         // We need to enable the popover again as the element is new

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -97,6 +97,7 @@
                                     </li>
                                     <li>
                                         <a href="#resetValues" id="resetValues">Reset to default values</a>
+                                        <input type="hidden" id="updateURL" value="{% url 'current_default_variables' instrument=instrument %}">
                                         <div class="js-explaination visible-xs-block">Reset all variables to those set in the script. This will pick up any changes made to the reduce_vars.py script.</div>
                                     </li>
                                     <div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -96,8 +96,7 @@
                                         <div class="js-explaination visible-xs-block">Download the reduction script with the selected variables inserted.</div>
                                     </li>
                                     <li>
-                                        <a href="#resetValues" id="resetValues">Reset to default values</a>
-                                        <input type="hidden" id="updateURL" value="{% url 'current_default_variables' instrument=instrument %}">
+                                        <a href="#currentScript" id="currentScript">Reset to values in current script</a>
                                         <div class="js-explaination visible-xs-block">Reset all variables to those set in the script. This will pick up any changes made to the reduce_vars.py script.</div>
                                     </li>
                                     <div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/edit_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/edit_variables.html
@@ -1,6 +1,7 @@
 {% load variable_type %}
 
 <input type="hidden" id="preview_url" value="{% url 'preview_script' instrument=instrument %}"/>
+<input type="hidden" id="updateURL" value="{% url 'current_default_variables' instrument=instrument %}"/>
 {% for name,variable in standard_variables.items %}
     <div class="form-group">
         <label for="var-standard-{{variable.sanitized_name}}" class="control-label col-md-3">

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/run_variables.html
@@ -41,7 +41,7 @@
                                 </li>
                                 <li>
                                     <a href="#currentScript" id="currentScript">Reset to current script and values</a>
-                                    <div class="js-explaination visible-xs-block">Reset to use the current script and the default variables that ot contains.</div>
+                                    <div class="js-explaination visible-xs-block">Reset to use the current script and the default variables that it contains.</div>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
Fixes #196 

When reset to current variables is pressed an ajax get request is sent to http://reduce.isis.cclrc.ac.uk/instrument/INST/default_variables, which reads the script. The form is then updated from these values. NOTE: There may be a much better way of doing this as creating a new page that is only used occasionally seems inefficient. Therefore it may be worth revisiting this code when the bugfix is less time critical.

This has also fixed the same bug which was occurring when resetting the script to current values on re-runs.

To test:
1. Open the edit upcoming configuration screen
2. Edit reduce_vars.py on the instrument to add/remove variables
3. Click Reset to values in current script
4. Confirm that the form updates with the new set of variables
5. Open a re-run and repeat steps 2-4