### PR TITLE
Fix bug where help text not being propagated

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -169,6 +169,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
                     is_advanced=default_var.is_advanced, 
                     type=default_var.type,
                     tracks_script=track_scripts,
+                    help_text=default_var.help_text,
                     )
                 if is_run_range:
                     variable.start_run = start

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_variables.js
@@ -321,10 +321,11 @@
             $form.find('.js-variables-container').html(data);
             $("body").css("cursor", "default");
             $("#currentScript").css("cursor", "pointer");
+
+            // We need to enable the popover again as the element is new
+            $('[data-toggle="popover"]').popover();
         });
         $('#use_current_script').val("true");
-        // We need to enable the popover again as the element is new
-        $('[data-toggle="popover"]').popover();
     };
 
     var toggleTrackScript = function toggleTrackScript(event) {


### PR DESCRIPTION
Fixes #202 

To test:
* Go to an instrument where the help text has been lost e.g. MERLIN
* Edit the current variables and reset them to current script (this will force the pick up of help text)
* Save the variables
* Open the edit variables again, confirm help text is present
* Send a run that has not been performed on the instrument before (e.g. send an old run using the trigger script or wait for a run from the instrument) this should now have associated help_text

NOTE: Re-running an old run will not give you help text back as the variables are copied from the old run (which don't have associated help text). To give an old run help text again you must reset it to the current script and values before re-running it.