### PR TITLE
Removed checks for permission

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 '''
 def instrument_summary(request, instrument):
     # Check the user has permission
-    if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
+    #if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
+    #    raise PermissionDenied()
 
     instrument = Instrument.objects.get(name=instrument)
     
@@ -89,12 +89,13 @@ def instrument_summary(request, instrument):
 
     return render_to_response('snippets/instrument_summary_variables.html', context_dictionary, RequestContext(request))
 
-@require_staff
+#@require_staff
+@login_and_uows_valid
 @render_with('instrument_variables.html')
 def instrument_variables(request, instrument, start=0, end=0, experiment_reference=0):
     # Check the user has permission
-    if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
+    #if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
+    #    raise PermissionDenied()
     
     instrument = Instrument.objects.get(name=instrument)
     script = None
@@ -265,7 +266,8 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 
         return context_dictionary
 
-@require_staff
+#@require_staff
+@login_and_uows_valid
 @render_with('snippets/edit_variables.html')
 def current_default_variables(request, instrument):
     variables = InstrumentVariablesUtils().get_default_variables(instrument)
@@ -322,7 +324,8 @@ def run_summary(request, run_number, run_version=0):
     context_dictionary.update(csrf(request))
     return render_to_response('snippets/run_variables.html', context_dictionary, RequestContext(request))
 
-@require_staff
+#@require_staff
+@login_and_uows_valid
 @render_with('run_confirmation.html')
 def run_confirmation(request, run_number, run_version=0):
     reduction_run = ReductionRun.objects.get(run_number=run_number, run_version=run_version)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -52,7 +52,8 @@ def logout(request):
     request.session.flush()
     return redirect('index')
 
-@require_staff
+#@require_staff
+@login_and_uows_valid
 @render_with('run_queue.html')
 def run_queue(request):
     complete_status = StatusUtils().get_completed()
@@ -106,7 +107,7 @@ def run_list(request):
         instrument_obj = {
             'name' : instrument_name,
             'experiments' : [],
-            'is_instrument_scientist' : (instrument_name in owned_instruments),
+            'is_instrument_scientist' : True,#(instrument_name in owned_instruments),
             'runs' : [],
             'is_active' : instrument.is_active
         }
@@ -175,7 +176,7 @@ def run_summary(request, run_number, run_version=0):
     try:
         run = ReductionRun.objects.get(run_number=run_number, run_version=run_version)
         # Check the user has permission
-        if not request.user.is_superuser and run.experiment.reference_number not in request.session['experiments'] and run.instrument.name not in request.session['owned_instruments']:
+        if not request.user.is_superuser and str(run.experiment.reference_number) not in request.session['experiments']:
             raise PermissionDenied()
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
         context_dictionary = {
@@ -187,12 +188,13 @@ def run_summary(request, run_number, run_version=0):
         context_dictionary = {}
     return context_dictionary
 
-@require_staff
+#@require_staff
+@login_and_uows_valid
 @render_with('instrument_summary.html')
 def instrument_summary(request, instrument):
     # Check the user has permission
-    if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
+    #if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
+    #    raise PermissionDenied()
 
     processing_status = StatusUtils().get_processing()
     queued_status = StatusUtils().get_queued()
@@ -251,7 +253,7 @@ def experiment_summary(request, reference_number):
         context_dictionary = {}
     
     #Check the users permissions
-    if not request.user.is_superuser and reference_number not in request.session['experiments'] and experiment_details['instrument'] not in request.session['owned_instruments']:
+    if not request.user.is_superuser and str(reference_number) not in request.session['experiments']:
        raise PermissionDenied()
     return context_dictionary
 

--- a/WebApp/ISIS/autoreduce_webapp/templates/navbar.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/navbar.html
@@ -22,11 +22,9 @@
                      <li>
                         <a href="{% url 'run_list' %}">All Jobs</a>
                     </li>
-                    {% if user.is_staff or user.is_superuser %}
                     <li>
                         <a href="{% url 'run_queue' %}">Job Queue</a>
                     </li>
-                    {% endif %}                    
                     {% if user.is_superuser %}
                     <li>
                         <a href="{% url 'admin:index' %}">Admin</a>


### PR DESCRIPTION
Fixes #206 

For the moment the checks for owned instruments have been removed as this means only instrument scientists are able to use most of the features of the WebApp.

To test:
* Login to the WebApp as a user
* Confirm that you can view all expected runs and instruments
* Confirm that you can submit re-runs