### PR TITLE
Save results to multiple directories

### DIFF
--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -250,16 +250,16 @@ class PostProcessAdmin:
 
             # If the reduce script specified some additional save directories, copy to there first
             if out_directories:
-                if type(out_directories) is str and not os.access(out_directories, os.R_OK):
-                    self.log_and_message("Unable to access directory: %s" % out_directories)
-                if type(out_directories) is str and os.access(out_directories, os.R_OK):
+                if type(out_directories) is str:
                     self.copy_temp_directory(reduce_result_dir, out_directories)
                 elif type(out_directories) is list:
                     for out_dir in out_directories:
-                        if type(out_dir) is str and os.access(out_dir, os.R_OK):
+                        if type(out_dir) is str:
                             self.copy_temp_directory(reduce_result_dir, out_directories)
                         else:
-                            self.log_and_message("Unable to access directory: %s" % out_dir)
+                            self.log_and_message("Optional output directories of reduce.py must be strings: %s" % out_dir)
+                else:
+                    self.log_and_message("Optional output directories of reduce.py must be a string or list of stings: %s" % out_directories)
 
             # no longer a need for the temp directory used for temporary storing of reduction results
             self.delete_temp_directory(reduce_result_dir)

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -255,7 +255,7 @@ class PostProcessAdmin:
                 elif type(out_directories) is list:
                     for out_dir in out_directories:
                         if type(out_dir) is str:
-                            self.copy_temp_directory(reduce_result_dir, out_directories)
+                            self.copy_temp_directory(reduce_result_dir, out_dir)
                         else:
                             self.log_and_message("Optional output directories of reduce.py must be strings: %s" % out_dir)
                 else:


### PR DESCRIPTION
Fixes #210 

To test:

* temporarily change the WISH reduce.py to save to a folder like `output_folder = '/ceph/instrument/WISH/CYCLE20151/RB1510257/testing/autoreduced/'`

* re-run a job for this RB number

observe that:

* just completes successfully
* clicking on the job multiple reduced output folders are specified
* reduced data have been saved successfully to disk