### PR TITLE
Format changes for smaller devices

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
@@ -7,7 +7,7 @@
             <div class="col-md-12">
                 <div class="form-group">
                     <label for="run_search" class="screenreader-only">Search</label>
-                    <input type="search" placeholder="Search" name="run_search" id="run_search" class="form-control" autocomplete="off" data-toggle="popover" data-trigger="focus" data-content="Try entering an RB number or run number." data-placement="left">
+                    <input type="search" placeholder="Search" name="run_search" id="run_search" class="form-control" autocomplete="off" data-toggle="popover" data-trigger="focus" data-content="Try entering an RB number or run number." data-placement="top">
                 </div>
             </div>
         </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
@@ -3,7 +3,7 @@
         <div class="col-md-1 col-xs-1">
             <a href="#" class="js-toggle-instrument-children" title="Expand/Collapse"><i class="fa fa-lg fa-chevron-right"></i></a>
         </div>
-        <div class="col-md-6 col-xs-6">
+        <div class="col-md-5 col-sm-7 col-xs-5">
             {% if instrument.is_active %}
                 <a href="{% url 'instrument_summary' instrument.name %}">{{ instrument.name }}</a>
             {% else %}
@@ -22,11 +22,11 @@
             </div>
         </div>
 
-        <div class="col-md-2 col-xs-2">
+        <div class="col-md-3 col-sm-2 hidden-xs">
             <a href="{% url 'instrument_submit_runs' instrument.name %}" class="pull-right edit-instrument-variables">Submit<span class="hidden-xs hidden-sm"> New Jobs</span></a>
         </div>
 
-        <div class="col-md-3 col-xs-2">
+        <div class="col-md-3 col-sm-2 hidden-xs">
             {% if reduction_variables_on and instrument.is_active %}
                 {% if instrument.is_instrument_scientist or user.is_superuser %}
                     <a href="{% url 'instrument_variables' instrument.name %}" class="pull-right edit-instrument-variables">Configure<span class="hidden-xs hidden-sm"> Future Variables</span></a>


### PR DESCRIPTION
Fixes #212, fixes #213 

This pull request fixes a number of issues found when using smaller screens. Configure/Submit links should now display full text on widescreen, one word on smaller screens and disappear for very small screens. The popover for the search bar will now appear above the bar, rather than to the side where it was cut.

To test:
* Window a browser on the All Jobs page.
* Adjust the width of the browser, confirm that the submit and configure links change as expected with browser width
* At a small width click on the search bar, confirm that the popover is entirely visible.