### PR TITLE
Changed labels to be more consistent

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_summary.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_summary.html
@@ -16,7 +16,7 @@
             </div>
             <div class="row">
                 <div class="col-md-4 col-md-offset-4 text-center">
-                    <p><a href="{% url 'instrument_submit_runs' instrument=instrument %}" class="btn btn-success btn-block"><i class="fa fa-plus"></i> Submit new runs</a></p>
+                    <p><a href="{% url 'instrument_submit_runs' instrument=instrument %}" class="btn btn-success btn-block"><i class="fa fa-plus"></i> Re-run past jobs</a></p>
                 </div>
             </div>
             {% if reduction_variables_on %}  

--- a/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/instrument_variables.html
@@ -7,7 +7,7 @@
         {% if instrument.is_active %}
             <div class="row">
                 <div class="col-md-12 text-center">
-                    <h2>{{ instrument.name }} - Edit Future Configuration</h2>
+                    <h2>{{ instrument.name }} - Configure New Jobs</h2>
                 </div>
             </div>
             <div class="row">

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_summary_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_summary_variables.html
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-md-4 col-md-offset-4 text-center">
-        <p><a href="{% url 'instrument_variables' instrument=instrument %}" class="btn btn-success btn-block"><i class="fa fa-plus"></i> Add new run variables</a></p>
+        <p><a href="{% url 'instrument_variables' instrument=instrument %}" class="btn btn-success btn-block"><i class="fa fa-plus"></i> Configure new jobs</a></p>
     </div>
 </div>
 

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
@@ -23,13 +23,13 @@
         </div>
 
         <div class="col-md-3 col-sm-2 hidden-xs">
-            <a href="{% url 'instrument_submit_runs' instrument.name %}" class="pull-right edit-instrument-variables">Submit<span class="hidden-xs hidden-sm"> New Jobs</span></a>
+            <a href="{% url 'instrument_submit_runs' instrument.name %}" class="pull-right edit-instrument-variables">Re-run<span class="hidden-xs hidden-sm"> Past Jobs</span></a>
         </div>
 
         <div class="col-md-3 col-sm-2 hidden-xs">
             {% if reduction_variables_on and instrument.is_active %}
                 {% if instrument.is_instrument_scientist or user.is_superuser %}
-                    <a href="{% url 'instrument_variables' instrument.name %}" class="pull-right edit-instrument-variables">Configure<span class="hidden-xs hidden-sm"> Future Variables</span></a>
+                    <a href="{% url 'instrument_variables' instrument.name %}" class="pull-right edit-instrument-variables">Configure<span class="hidden-xs hidden-sm"> New Jobs</span></a>
                 {% endif %}
             {% endif %}
         </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/submit_runs.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/submit_runs.html
@@ -7,7 +7,7 @@
         {% if instrument.is_active %}
             <div class="row">
                 <div class="col-md-12 text-center">
-                    <h2>{{ instrument.name }} - Submit New Jobs</h2>
+                    <h2>{{ instrument.name }} - Re-run past jobs</h2>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
Fixes #216 

To test:
* Ensure that "Submit New Runs" is now referred to as "Re-run past jobs" in all places
* Ensure that "Edit future configuration" is now reffered to as "Configure new jobs" in all places