### PR TITLE
Entering variables that are too long gives error

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -318,11 +318,17 @@ def submit_runs(request, instrument):
             default_variables = InstrumentVariablesUtils().get_variables_from_current_script(instrument.name)
 
             script = ScriptFile(script=script_binary, file_name='reduce.py')
-            script.save()
             script_vars = ScriptFile(script=script_vars_binary, file_name='reduce_vars.py')
-            script_vars.save()
 
             #TODO: Share code with run_confirmation
+
+            queue_count = ReductionRun.objects.filter(instrument=instrument, status=queued_status).count()
+
+            context_dictionary = {
+                'run' : None,
+                'variables' : None,
+                'queued' : queue_count,
+            }
 
             new_variables = []
 
@@ -341,7 +347,7 @@ def submit_runs(request, instrument):
                         if not default_var:
                             continue
                         if len(value) > InstrumentVariable._meta.get_field('value').max_length:
-                            raise DataTooLong #TODO: Should not save any variables
+                            context_dictionary['error'] = 'Value given in ' + str(key) + ' is too long.'
                         variable = RunVariable(
                             reduction_run=new_job,
                             name=default_var.name,
@@ -350,26 +356,20 @@ def submit_runs(request, instrument):
                             type=default_var.type,
                             help_text=default_var.help_text
                         )
-                        variable.save()
-                        variable.scripts.add(script)
-                        variable.scripts.add(script_vars)
-                        variable.save()
                         new_variables.append(variable)
 
-            queue_count = ReductionRun.objects.filter(instrument=instrument, status=queued_status).count()
-
-            context_dictionary = {
-                'run' : None,
-                'variables' : None,
-                'queued' : queue_count,
-            }
-
             if len(new_variables) == 0:
-                new_job.delete()
-                script.delete()
-                script_vars.delete()
                 context_dictionary['error'] = 'No variables were found to be submitted.'
-            else:
+
+            if 'error' not in context_dictionary:
+                script.save()
+                script_vars.save()
+                for variable in new_variables:
+                    variable.save()
+                    variable.scripts.add(script)
+                    variable.scripts.add(script_vars)
+                    variable.save()
+
                 try:
                     MessagingUtils().send_pending(new_job)
                     context_dictionary['run'] = new_job
@@ -379,6 +379,8 @@ def submit_runs(request, instrument):
                     script.delete()
                     script_vars.delete()
                     context_dictionary['error'] = 'Failed to send new job. (%s)' % str(e)
+            else:
+                new_job.delete()
 
         return redirect('instrument_summary', instrument=instrument.name)
     else:
@@ -511,9 +513,15 @@ def run_confirmation(request, run_number, run_version=0):
             default_variables = run_variables
 
         script = ScriptFile(script=script_binary, file_name='reduce.py')
-        script.save()
         script_vars = ScriptFile(script=script_vars_binary, file_name='reduce_vars.py')
-        script_vars.save()
+
+        queue_count = ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count()
+
+        context_dictionary = {
+            'run' : None,
+            'variables' : None,
+            'queued' : queue_count,
+        }
 
         new_variables = []
 
@@ -532,7 +540,7 @@ def run_confirmation(request, run_number, run_version=0):
                     if not default_var:
                         continue
                     if len(value) > InstrumentVariable._meta.get_field('value').max_length:
-                        raise DataTooLong
+                        context_dictionary['error'] = 'Value given in ' + str(name) + ' is too long.'
                     variable = RunVariable(
                         reduction_run=new_job,
                         name=default_var.name,
@@ -541,26 +549,20 @@ def run_confirmation(request, run_number, run_version=0):
                         type=default_var.type,
                         help_text=default_var.help_text
                     )
-                    variable.save()
-                    variable.scripts.add(script)
-                    variable.scripts.add(script_vars)
-                    variable.save()
                     new_variables.append(variable)
 
-        queue_count = ReductionRun.objects.filter(instrument=reduction_run.instrument, status=queued_status).count()
-
-        context_dictionary = {
-            'run' : None,
-            'variables' : None,
-            'queued' : queue_count,
-        }
-
         if len(new_variables) == 0:
-            new_job.delete()
-            script.delete()
-            script_vars.delete()
             context_dictionary['error'] = 'No variables were found to be submitted.'
-        else:
+
+        if 'error' not in context_dictionary:
+            script.save()
+            script_vars.save()
+            for variable in new_variables:
+                variable.save()
+                variable.scripts.add(script)
+                variable.scripts.add(script_vars)
+                variable.save()
+
             try:
                 MessagingUtils().send_pending(new_job)
                 context_dictionary['run'] = new_job
@@ -570,6 +572,8 @@ def run_confirmation(request, run_number, run_version=0):
                 script.delete()
                 script_vars.delete()
                 context_dictionary['error'] = 'Failed to send new job. (%s)' % str(e),
+        else:
+            new_job.delete()
 
         return context_dictionary
     else:


### PR DESCRIPTION
Fixes #169 

To test:
* Go to re-run a run
* Enter text in one of the variables that is longer than the database limit (currently 5000 chars)
* Submit run
* Confirm that a sensible error message is given and no run is sent

Note: This does not work for multiple re-runs, this can be done in #242 