### PR TITLE
Preview scripts now shows new variable values

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -64,7 +64,7 @@ class VariableUtils(object):
             list_values = value.split(',')
             number_list = []
             for val in list_values:
-                if re.match("[0-9.]+", val.strip()):
+                if re.match("[\-0-9.]+", val.strip()):
                     number_list.append(val)
             return '[%s]' % ','.join(number_list)
         if var_type == 'list_text':

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -505,8 +505,8 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         %s is later replaced with the variable name
         A live example can be found at: https://regex101.com/r/oJ7iY5/3
     '''
-    standard_pattern = "(?P<before>(\s)standard_vars\s*=\s*\{(([\s\S])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,(\s+)\n|\n)[\S\s])+)"
-    advanced_pattern = "(?P<before>(\s)advanced_vars\s*=\s*\{(([\s\S])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,(\s+)\n|\n)[\S\s])+)"
+    standard_pattern = "(?P<before>(\s*)standard_vars\s*=\s*\{(([^}])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,(\s+)\n|\n)[\S\s])+)"
+    advanced_pattern = "(?P<before>(\s*)advanced_vars\s*=\s*\{(([^}])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,(\s+)\n|\n)[\S\s])+)"
 
     instrument_object = Instrument.objects.get(name=instrument)
 
@@ -533,7 +533,7 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
             script_vars_file = re.sub(pattern, value, script_vars_file)
 
     elif request.method == 'POST':
-        experiment_reference = request.POST.get('experiment_reference_number', None)
+        experiment_reference = request.POST.get('experiment_reference_number', 0)
         start_run = request.POST.get('run_start', None)
         lookup_run_number = request.POST.get('run_number', None)
         lookup_run_version = request.POST.get('run_version', None)


### PR DESCRIPTION
Fixes #184 

To Test:
* Go to re-run a variable
* Modify a variable
* Preview script
* Confirm the modified variable is present in the previewed script
* Repeat for preview script on instrument summary page and batch re-run page
* Also confirm that negative numbers in lists are replaced in the preview 