### PR TITLE
Improved formatting of help text

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -1,4 +1,4 @@
-import logging, os, sys, imp, uuid, re, json, time, datetime
+import logging, os, sys, imp, uuid, re, json, time, datetime, cgi
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
 from autoreduce_webapp.settings import ACTIVEMQ, TEMP_OUTPUT_DIRECTORY, REDUCTION_DIRECTORY, FACILITY
@@ -320,15 +320,20 @@ class InstrumentVariablesUtils(object):
             variables.extend(self._create_variables(instrument, reduce_script, reduce_script.advanced_vars, True))
         return variables
 
+    def _replace_special_chars(self, help_text):
+        help_text = cgi.escape(help_text)  # Remove any HTML already in the help string
+        help_text = help_text.replace('\n', '<br>').replace('\t', '&nbsp;&nbsp;&nbsp;&nbsp;')
+        return help_text
+
     def get_help_text(self, dictionary, key, instrument_name, reduce_script=None):
         if not dictionary or not key:
             return ""
         if not reduce_script:
-            reduce_script, script_binary =  self.__load_reduction_vars_script(instrument_name)
+            reduce_script, script_binary = self.__load_reduction_vars_script(instrument_name)
         if 'variable_help' in dir(reduce_script):
             if dictionary in reduce_script.variable_help:
                 if key in reduce_script.variable_help[dictionary]:
-                    return reduce_script.variable_help[dictionary][key]
+                    return self._replace_special_chars(reduce_script.variable_help[dictionary][key])
         return ""
 
     def get_current_and_upcoming_variables(self, instrument_name):

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/edit_variables.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/edit_variables.html
@@ -7,7 +7,7 @@
         <label for="var-standard-{{variable.sanitized_name}}" class="control-label col-md-3">
             {{variable.name}}
             {% if variable.help_text %}
-                <a href="#" data-toggle="popover" data-content="{{ variable.help_text }}" data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
+                <a href="#" data-toggle="popover" data-html="true" data-content="{{ variable.help_text }}" data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
             {% endif %}
         </label>
         <div class="col-md-9">
@@ -31,7 +31,7 @@
                     <label for="var-advanced-{{variable.sanitized_name}}" class="control-label col-md-3">
                         {{variable.name}}
                         {% if variable.help_text %}
-                            <a href="#" data-toggle="popover" data-content="{{ variable.help_text }}" data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
+                            <a href="#" data-toggle="popover" data-html="true" data-content="{{ variable.help_text }}" data-trigger="hover click focus" data-placement="top" data-container="body"><i class="fa fa-info-circle"></i></a>
                         {% endif %}
                     </label>                    
                     <div class="col-md-9">


### PR DESCRIPTION
Fixes #127 

To test:
* Add a \n and \t to some reduction help text
* Go to a job re-run page
* Update the variables to those in the current script
* Confirm that the special characters appear in the popover help text
* Add special HTML to help text (e.g. <br>, &nbsp;), repeat process and confirm this appears as normal text in popover