### PR TITLE
Fixed the same RB number for multiple instruments

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -131,7 +131,7 @@ def run_list(request):
         matching_experiments = Experiment.objects.filter(reference_number__in=reference_numbers)
         for experiment in matching_experiments:
             # get all runs for experiment
-            runs = ReductionRun.objects.filter(experiment=experiment).order_by('-created')
+            runs = ReductionRun.objects.filter(experiment=experiment, instrument=instrument).order_by('-created')
 
             # count how many are in status error, queued and processing
             experiment_error_runs = runs.filter(status__exact=status_error).count()


### PR DESCRIPTION
Fixes #156 

To test:
* Submit a new run via a trigger script that has the same RB number as a run on a different instrument
* Confirm the new run only appears under the expected instrument
* Confirm that the page for the specific run can be properly loaded 