### PR TITLE
Added failure-handling functionality

### DIFF
--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -243,9 +243,6 @@ class PostProcessAdmin:
             # no longer a need for the temp directory used for temporary storing of reduction results
             self.delete_temp_directory(reduce_result_dir)
 
-            self.client.send(self.conf['reduction_complete'] , json.dumps(self.data))
-            logger.info("\nCalling: "+self.conf['reduction_complete'] + "\n" + json.dumps(self.data) + "\n")
-
         except Exception, e:
             self.data["message"] = "REDUCTION Error: %s " % e
 

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/PostProcessAdmin.py
@@ -240,12 +240,14 @@ class PostProcessAdmin:
                 else:
                     self.log_and_message("Optional output directories of reduce.py must be a string or list of stings: %s" % out_directories)
 
+                    
             # no longer a need for the temp directory used for temporary storing of reduction results
             self.delete_temp_directory(reduce_result_dir)
 
-        except Exception, e:
+        except Exception as e:
             self.data["message"] = "REDUCTION Error: %s " % e
 
+            
         if self.data["message"] != "":
             # This means an error has been produced somewhere
             try:
@@ -256,7 +258,7 @@ class PostProcessAdmin:
                 logger.info("Reduction job failed")
         else:
             self.client.send(self.conf['reduction_complete'], json.dumps(self.data))
-            print "\nCalling: " + self.conf['reduction_complete'] + "\n" + json.dumps(self.data) + "\n"
+            print("\nCalling: " + self.conf['reduction_complete'] + "\n" + json.dumps(self.data) + "\n")
             logger.info("Reduction job successfully complete")
 
     def _send_error_and_log(self):
@@ -275,7 +277,7 @@ class PostProcessAdmin:
         logger.info("Moving %s to %s" % (temp_result_dir, copy_destination))
         try:
             self._copy_tree(temp_result_dir, copy_destination)
-        except Exception, e:
+        except Exception as e:
             self.log_and_message("Unable to copy to %s - %s" % (copy_destination, e))
 
 
@@ -284,7 +286,7 @@ class PostProcessAdmin:
         logger.info("Remove temp dir %s " % temp_result_dir)
         try:
             shutil.rmtree(temp_result_dir, ignore_errors=True)
-        except Exception, e:
+        except Exception as e:
             logger.info("Unable to remove temporary directory %s - %s" % temp_result_dir)
 
 
@@ -340,7 +342,7 @@ class PostProcessAdmin:
             self.log_and_message("Unable to remove existing directory %s - %s" % (directory, e))
 
 if __name__ == "__main__":
-    print "\n> In PostProcessAdmin.py\n"
+    print("\n> In PostProcessAdmin.py\n")
 
     try:
         conf = json.load(open('/etc/autoreduce/post_process_consumer.conf'))

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -9,8 +9,9 @@ from django.utils import timezone
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 sys.path.insert(0, BASE_DIR)
 from reduction_viewer.models import ReductionRun, ReductionLocation, DataLocation, Experiment
-from reduction_variables.models import RunVariable
 from reduction_viewer.utils import StatusUtils, InstrumentUtils
+from reduction_variables.models import RunVariable
+from reduction_variables.utils import ReductionVariablesUtils
 from icat_communication import ICATCommunication
 from django.db import connection
 import django
@@ -195,20 +196,27 @@ class Listener(object):
             logger.info("Run %s has encountered an error - %s" % (self._data_dict['run_number'], self._data_dict['message']))
         else:
             logger.info("Run %s has encountered an error - No error message was found" % (self._data_dict['run_number']))
+            
+        if 'reduction_script' in self._data_dict:
+            self.clean_up_reduction_script(self._data_dict['reduction_script'])
         
         reduction_run = self.find_run()
                     
-        if reduction_run:
-            reduction_run.status = StatusUtils().get_error()
-            reduction_run.finished = timezone.now().replace(microsecond=0)
-            if 'message' in self._data_dict:
-                reduction_run.message = self._data_dict['message']
-            reduction_run.save()
-        else:
+        if not reduction_run:
             logger.error("A reduction run that caused an error wasn't found in the database. Experiment: %s, Run Number: %s, Run Version %s" % (self._data_dict['rb_number'], self._data_dict['run_number'], self._data_dict['run_version']))
-
-        if 'reduction_script' in self._data_dict:
-            self.clean_up_reduction_script(self._data_dict['reduction_script'])
+            return
+        
+        reduction_run.status = StatusUtils().get_error()
+        reduction_run.finished = timezone.now().replace(microsecond=0)
+        if 'message' in self._data_dict:
+            reduction_run.message = self._data_dict['message']
+        reduction_run.save()
+        
+        notifyRunFailure(reduction_run)
+        
+        if 'retry_in' in self._data_dict:
+            
+            retryRun(reduction_run, self._data_dict["retry_in"])
         
         
     def find_run(self):
@@ -219,6 +227,20 @@ class Listener(object):
 
         reduction_run = ReductionRun.objects.get(experiment=experiment, run_number=int(self._data_dict['run_number']), run_version=int(self._data_dict['run_version']))
         return reduction_run
+        
+        
+    def notifyRunFailure(self, reductionRun):
+        pass
+        
+    def retryRun(self, reductionRun, retryIn):
+        reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=retryIn)
+        
+        new_job = ReductionVariablesUtils().createRetryRun(reductionRun)          
+        try:
+            MessagingUtils().send_pending(new_job, delay=retryIn*1000) # seconds to ms
+        except Exception as e:
+            new_job.delete()
+            raise e
         
 
 class Client(object):
@@ -275,11 +297,15 @@ class Client(object):
             self._connection.stop()
         self._connection = None
 
-    def send(self, destination, message, persistent='true', priority='4'):
+    def send(self, destination, message, persistent='true', priority='4', delay=None):
         if self._connection is None or not self._connection.is_connected():
             self._disconnect()
             self._connection = self.get_connection()
-        self._connection.send(destination, message, persistent=persistent, priority=priority)
+            
+        headers = {}
+        if delay:
+            headers['AMQ_SCHEDULED_DELAY'] = str(delay)
+        self._connection.send(destination, message, persistent=persistent, priority=priority, headers=headers)
         logger.debug("[%s] send message to %s" % (self._consumer_name, destination))
 
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -95,7 +95,8 @@ STATICFILES_DIRS = (
 
 LOG_FILE = os.path.join(BASE_DIR, 'autoreduction.log')
 if DEBUG:
-    LOG_LEVEL = 'DEBUG'
+    #LOG_LEVEL = 'DEBUG' 
+    LOG_LEVEL = 'INFO'
 else:
     LOG_LEVEL = 'INFO'
 
@@ -125,9 +126,10 @@ LOGGING = {
             'propagate': True,
             'level':LOG_LEVEL,
         },
-        'MYAPP': {
-            'handlers': ['file'],
-            'level': LOG_LEVEL,
+        'app' : {
+            'handlers':['file'],
+            'propagate': True,
+            'level':'DEBUG',
         },
     }
 }

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -176,6 +176,13 @@ ICAT = {
 UOWS_URL = 'https://fitbawebdev.isis.cclrc.ac.uk:8181/UserOfficeWebService/UserOfficeWebService?wsdl'
 UOWS_LOGIN_URL = 'https://devusers.facilities.rl.ac.uk/auth/?service=http://datareducedev.isis.cclrc.ac.uk&redirecturl='
 
+
+# Email for notifications
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'exchsmtp.stfc.ac.uk'
+EMAIL_PORT = 25
+ERROR_EMAILS = ['isisreduce@stfc.ac.uk']
+
 # Constant vars
 
 FACILITY = "ISIS"

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -15,6 +15,7 @@ urlpatterns = patterns('',
 
     url(r'^runs/$', reduction_viewer_views.run_list, name='run_list'),   
     url(r'^runs/queue/$', reduction_viewer_views.run_queue, name='run_queue'), 
+    url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'), 
     url(r'^runs/(?P<run_number>[0-9]+)(?:/(?P<run_version>[0-9]+))?/$', reduction_viewer_views.run_summary, name='run_summary'),
     url(r'^runs/(?P<instrument>\w+)/confirmation/$', reduction_variables_views.run_confirmation, name='run_confirmation'),
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -427,6 +427,9 @@ class ReductionVariablesUtils(object):
             )
         new_job.save()
         
+        reductionRun.retry_run = new_job
+        reductionRun.save()
+        
         # copy the previous data locations
         for data_location in reductionRun.data_location.all():
             new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -411,7 +411,7 @@ def run_confirmation(request, instrument):
 
 
             use_current_script = request.POST.get('use_current_script', u"true").lower() == u"true"
-
+                
             if use_current_script:
                 script_binary, script_vars_binary = InstrumentVariablesUtils().get_current_script_text(instrument.name)
                 default_variables = InstrumentVariablesUtils().get_variables_from_current_script(instrument.name)
@@ -419,7 +419,7 @@ def run_confirmation(request, instrument):
                 run_variables = old_reduction_run.run_variables.all()
                 script_binary, script_vars_binary = ScriptUtils().get_reduce_scripts_binary(run_variables[0].scripts.all())
                 default_variables = run_variables
-                
+
             script = ScriptFile(script=script_binary, file_name='reduce.py')
             script_vars = ScriptFile(script=script_vars_binary, file_name='reduce_vars.py')
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -41,6 +41,7 @@ class ReductionRun(models.Model):
     message = models.CharField(max_length=255, blank=True)
     graph = SeparatedValuesField(null=True, blank=True)
     hidden_in_failviewer = models.BooleanField(default=False)
+    retry_when = models.DateTimeField(null=True, blank=True)
 
     def __unicode__(self):
         if self.run_name:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -40,6 +40,7 @@ class ReductionRun(models.Model):
     finished = models.DateTimeField(null=True, blank=True)
     message = models.CharField(max_length=255, blank=True)
     graph = SeparatedValuesField(null=True, blank=True)
+    hidden_in_failviewer = models.BooleanField(default=False)
 
     def __unicode__(self):
         if self.run_name:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -42,6 +42,8 @@ class ReductionRun(models.Model):
     graph = SeparatedValuesField(null=True, blank=True)
     hidden_in_failviewer = models.BooleanField(default=False)
     retry_when = models.DateTimeField(null=True, blank=True)
+    retry_run = models.ForeignKey('self', on_delete=models.CASCADE, null=True)
+    cancel = models.BooleanField(default=False)
 
     def __unicode__(self):
         if self.run_name:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -7,11 +7,10 @@ from django.db.models import Q
 from autoreduce_webapp.uows_client import UOWSClient
 from autoreduce_webapp.icat_communication import ICATCommunication
 from autoreduce_webapp.settings import UOWS_LOGIN_URL
-from reduction_viewer.models import Experiment, ReductionRun, Instrument, DataLocation
+from reduction_viewer.models import Experiment, ReductionRun, Instrument
 from reduction_viewer.utils import StatusUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
-from reduction_variables.models import RunVariable
-from reduction_variables.utils import MessagingUtils, InstrumentVariablesUtils
+from reduction_variables.utils import MessagingUtils, ReductionVariablesUtils
 from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_staff, require_admin
 import operator
 import json
@@ -100,46 +99,17 @@ def fail_queue(request):
                     
                     
                 elif action == "rerun":
-                
                     highest_version = max([int(runL[1]) for runL in selectedRuns if int(runL[0]) == runNumber])
                     if runVersion != highest_version:
                         continue # do not run multiples of the same run
                 
-                    last_version = -1
-                    for run in ReductionRun.objects.filter(experiment=experiment, run_number=runNumber):
-                        last_version = max(last_version, run.run_version)
-                        
-                    new_job = ReductionRun(
-                        instrument = reductionRun.instrument,
-                        run_number = reductionRun.run_number,
-                        run_name = "",
-                        run_version = last_version+1,
-                        experiment = reductionRun.experiment,
-                        #started_by=request.user.username,
-                        status = StatusUtils().get_queued()
-                        )
-                    new_job.save()
-                    
-                    for data_location in reductionRun.data_location.all():
-                        new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)
-                        new_data_location.save()
-                        new_job.data_location.add(new_data_location)
-                        
-                    for var in InstrumentVariablesUtils().get_variables_for_run(new_job):
-                        new_var = RunVariable(name=var.name, value=var.value, type=var.type, is_advanced=var.is_advanced, help_text=var.help_text)
-                        new_var.reduction_run = new_job
-                        new_job.run_variables.add(new_var)
-                        new_var.save()
-                        
-                        for script in var.scripts.all():
-                            new_var.scripts.add(script)          
+                    new_job = ReductionVariablesUtils().createRetryRun(reductionRun)
                     
                     try:
                         MessagingUtils().send_pending(new_job)
                     except Exception as e:
                         new_job.delete()
                         raise e
-
                         
                 elif action == "default":
                     pass

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -4,7 +4,6 @@ from django.http import JsonResponse
 from django.core.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
-from django.utils import timezone
 from autoreduce_webapp.uows_client import UOWSClient
 from autoreduce_webapp.icat_communication import ICATCommunication
 from autoreduce_webapp.settings import UOWS_LOGIN_URL
@@ -12,7 +11,7 @@ from reduction_viewer.models import Experiment, ReductionRun, Instrument
 from reduction_viewer.utils import StatusUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
 from reduction_variables.utils import MessagingUtils, ReductionVariablesUtils
-from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_staff, require_admin
+from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_admin
 import operator
 import json
 import logging
@@ -111,9 +110,6 @@ def fail_queue(request):
                     except Exception as e:
                         new_job.delete()
                         raise e
-                        
-                    reductionRun.retry_when = timezone.now().replace(microsecond=0)
-                    reductionRun.save()
                     
                         
                 elif action == "cancel":

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/fail_queue.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/fail_queue.js
@@ -2,21 +2,30 @@
     
     var runAction = function runAction()
     {
+        
+        // set form values
+        var action = $('#runAction').val();
+        $("[name='action']").attr('value', action);
+        
         var selectedRuns = $("[name='runCheckbox']").filter(':checked').map( function() {
             return [[$(this).attr('data-run_number'), $(this).attr('data-run_version'), $(this).attr('data-rb_number')]];
         }).get(); // a list of checked runs, each element of the form [run number, run version, RB number]
+        $("[name='selectedRuns']").attr('value', JSON.stringify(selectedRuns));
+        
+        
+        //Set cursor to waiting
+        $("body").css("cursor", "wait");
+        $("#variableSubmit").css("cursor", "wait");
+        
         
         // send POST to server to perform action
+        window.onbeforeunload = undefined;
         var url = $(location).attr('href');
-        var action = $('#runAction').val();
-        var data = { "selectedRuns": JSON.stringify(selectedRuns), "action": action, csrfmiddlewaretoken: window.CSRF_TOKEN};
-        $.post(url, data, postResponse);
-    }
-
-    var postResponse = function postResponse(data)
-    {
-        location.reload();
-    }
+        var aForm = $("#actionForm")
+        aForm.attr("action", url);
+        aForm.submit();
+    };
+    
     
     
     var toggleAllRuns = function toggleAllRuns()

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/fail_queue.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/fail_queue.js
@@ -1,0 +1,35 @@
+(function(){
+    
+    var runAction = function runAction()
+    {
+        var selectedRuns = $("[name='runCheckbox']").filter(':checked').map( function() {
+            return [[$(this).attr('data-run_number'), $(this).attr('data-run_version'), $(this).attr('data-rb_number')]];
+        }).get(); // a list of checked runs, each element of the form [run number, run version, RB number]
+        
+        // send POST to server to perform action
+        var url = $(location).attr('href');
+        var action = $('#runAction').val();
+        var data = { "selectedRuns": JSON.stringify(selectedRuns), "action": action, csrfmiddlewaretoken: window.CSRF_TOKEN};
+        $.post(url, data, postResponse);
+    }
+
+    var postResponse = function postResponse(data)
+    {
+        location.reload();
+    }
+    
+    
+    var toggleAllRuns = function toggleAllRuns()
+    {
+        $("[name='runCheckbox']").prop("checked", $('#selectAllRuns').is(":checked"));
+    }
+    
+    var init = function init() 
+    {
+        $('#runActionButton').on('click', runAction);
+        $('#selectAllRuns').on('click', toggleAllRuns);
+    };
+
+    init();
+    
+}())

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -6,54 +6,56 @@
 
 {% block body %}
     <title>Failed Jobs</title>
-    <div class="row">
-        <div class="col-md-12 text-center">
-            <h2>Failed Jobs</h2>
-        </div>
-    </div>
-    <div class="row">
-        <div>
-            <select id="runAction">
-                <option value="default">Select action to apply to selected runs</option>
-                <option value="rerun">Re-run selected</option>
-                <option value="hide">Hide selected</option>
-            </select>
-            <button type="button" id="runActionButton">Apply</button>
-        </div>
-    </div>
     {% if queue %}
-        <table class="table table-striped table-bordered">
-            <thead>
-                <tr>
-                    <th><input type='checkbox' id="selectAllRuns"></th>
-                    <th>Run Number</th>
-                    <th>Instrument</th>
-                    <th>Message</th>
-                    <th>Submitted</th>
-                    <th>Submitted By</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for job in queue %}
-                    <tr name='runRow' class="{% colour_table_row job.status.value %}">
-                        <td><input type='checkbox' name='runCheckbox' data-run_number='{{job.run_number}}' data-run_version='{{job.run_version}}' data-rb_number='{{job.experiment.reference_number}}'></td>
-                        <td>
-                            <a href="{% url 'run_summary' run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
-                        </td>
-                        <td>{{ job.instrument.name }}</td>
-                        <td style="width:600px;"><strong>{{ job.message }}</strong></td>
-                        <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
-                        <td>
-                            {% if job.started_by %}
-                                {% get_user_name job.started_by %}
-                            {% else %}
-                                Autoreduction Service
-                            {% endif %}
-                        </td>
+        <div class="column">
+            <div class="row">
+                <div class="col-md-12 text-center">
+                    <h2>Failed Jobs</h2>
+                </div>
+            </div>
+            <div>
+                <div>
+                    <select id="runAction">
+                        <option value="default">Select action to apply to selected runs</option>
+                        <option value="rerun">Re-run selected</option>
+                        <option value="hide">Hide selected</option>
+                    </select>
+                    <button type="button" id="runActionButton">Apply</button>
+                </div>
+            </div>
+            <table class="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th><input type='checkbox' id="selectAllRuns"></th>
+                        <th>Run Number</th>
+                        <th>Instrument</th>
+                        <th>Message</th>
+                        <th>Submitted</th>
+                        <th>Submitted By</th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for job in queue %}
+                        <tr name='runRow' class="{% colour_table_row job.status.value %}">
+                            <td><input type='checkbox' name='runCheckbox' data-run_number='{{job.run_number}}' data-run_version='{{job.run_version}}' data-rb_number='{{job.experiment.reference_number}}'></td>
+                            <td>
+                                <a href="{% url 'run_summary' run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
+                            </td>
+                            <td>{{ job.instrument.name }}</td>
+                            <td style="width:600px;"><strong>{{ job.message }}</strong></td>
+                            <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
+                            <td>
+                                {% if job.started_by %}
+                                    {% get_user_name job.started_by %}
+                                {% else %}
+                                    Autoreduction Service
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     {% else %}
         <div class="row">
             <div class="col-md-12 text-center">

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -14,14 +14,12 @@
                 </div>
             </div>
             <div>
-                <div>
-                    <select id="runAction">
-                        <option value="default">Select action to apply to selected runs</option>
-                        <option value="rerun">Re-run selected</option>
-                        <option value="hide">Hide selected</option>
-                    </select>
-                    <button type="button" id="runActionButton">Apply</button>
-                </div>
+                <select id="runAction">
+                    <option value="default">Select action to apply to selected runs</option>
+                    <option value="rerun">Re-run selected</option>
+                    <option value="hide">Hide selected</option>
+                </select>
+                <button type="button" id="runActionButton">Apply</button>
             </div>
             <table class="table table-striped table-bordered">
                 <thead>
@@ -31,7 +29,7 @@
                         <th>Instrument</th>
                         <th>Message</th>
                         <th>Submitted</th>
-                        <th>Submitted By</th>
+                        <th>Will retry</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -45,13 +43,12 @@
                             <td style="width:600px;"><strong>{{ job.message }}</strong></td>
                             <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
                             <td>
-                                {% if job.started_by %}
-                                    {% get_user_name job.started_by %}
+                                {% if job.retry_when %}
+                                    {{ job.retry_when|naturaltime }}
                                 {% else %}
-                                    Autoreduction Service
+                                    Never
                                 {% endif %}
                             </td>
-                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -16,8 +16,9 @@
             <div>
                 <select id="runAction">
                     <option value="default">Select action to apply to selected runs</option>
-                    <option value="rerun">Re-run selected</option>
-                    <option value="hide">Hide selected</option>
+                    <option value="rerun">Re-run </option>
+                    <option value="hide">Hide </option>
+                    <option value="cancel">Stop retrying</option>
                 </select>
                 <button type="button" id="runActionButton">Apply</button>
             </div>
@@ -29,12 +30,16 @@
                         <th>Instrument</th>
                         <th>Message</th>
                         <th>Submitted</th>
-                        <th>Will retry</th>
+                        <th>Retrying</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for job in queue %}
+                      {% if job.retry_run %}
+                        <tr name='runRow' class="{% colour_table_row job.retry_run.status.value %}">
+                      {% else %}
                         <tr name='runRow' class="{% colour_table_row job.status.value %}">
+                      {% endif %}
                             <td><input type='checkbox' name='runCheckbox' data-run_number='{{job.run_number}}' data-run_version='{{job.run_version}}' data-rb_number='{{job.experiment.reference_number}}'></td>
                             <td>
                                 <a href="{% url 'run_summary' run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
@@ -45,6 +50,12 @@
                             <td>
                                 {% if job.retry_when %}
                                     {{ job.retry_when|naturaltime }}
+                                    {% if job.cancel %}
+                                        <span> (Last attempt)</span>
+                                    {% endif %}
+                                    {% if job.retry_run %}
+                                        <a href="{% url 'run_summary' run_number=job.retry_run.run_number run_version=job.retry_run.run_version %}"> ({{ job.retry_run.status }})</a>
+                                    {% endif %}
                                 {% else %}
                                     Never
                                 {% endif %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -13,14 +13,24 @@
                     <h2>Failed Jobs</h2>
                 </div>
             </div>
+        {% if message %}
+            <div class="alert alert-danger word-wrap" role="alert">
+                <i class="fa fa-exclamation fa-exclamation-circle fa-lg"></i> {{ message }}
+            </div>
+        {% endif %}
             <div>
-                <select id="runAction">
+                <select id="runAction" style="float: left;">
                     <option value="default">Select action to apply to selected runs</option>
                     <option value="rerun">Re-run </option>
                     <option value="hide">Hide </option>
                     <option value="cancel">Stop retrying</option>
                 </select>
-                <button type="button" id="runActionButton">Apply</button>
+                <form id="actionForm" method="POST" action="{% url 'fail_queue' %}" style="float: left; padding-left: 5px;">
+                    <input type='hidden' name='csrfmiddlewaretoken' value='{{ csrf_token }}' />
+                    <input type="hidden" name="selectedRuns">
+                    <input type="hidden" name="action">
+                    <input type="submit" id="runActionButton" value="Apply">
+                </form>
             </div>
             <table class="table table-striped table-bordered">
                 <thead>
@@ -74,6 +84,5 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript"> window.CSRF_TOKEN = "{{ csrf_token }}"; </script>
     <script src='{% static "javascript/fail_queue.js" %}'> </script>
 {% endblock %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% load colour_table_rows %}
+{% load get_user_name %}
+{% load naturaltime from humanize %}
+{% load static from staticfiles %}
+
+{% block body %}
+    <title>Failed Jobs</title>
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <h2>Failed Jobs</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div>
+            <select id="runAction">
+                <option value="default">Select action to apply to selected runs</option>
+                <option value="rerun">Re-run selected</option>
+                <option value="hide">Hide selected</option>
+            </select>
+            <button type="button" id="runActionButton">Apply</button>
+        </div>
+    </div>
+    {% if queue %}
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th><input type='checkbox' id="selectAllRuns"></th>
+                    <th>Run Number</th>
+                    <th>Instrument</th>
+                    <th>Message</th>
+                    <th>Submitted</th>
+                    <th>Submitted By</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in queue %}
+                    <tr name='runRow' class="{% colour_table_row job.status.value %}">
+                        <td><input type='checkbox' name='runCheckbox' data-run_number='{{job.run_number}}' data-run_version='{{job.run_version}}' data-rb_number='{{job.experiment.reference_number}}'></td>
+                        <td>
+                            <a href="{% url 'run_summary' run_number=job.run_number run_version=job.run_version %}">{{ job.title }}</a>
+                        </td>
+                        <td>{{ job.instrument.name }}</td>
+                        <td style="width:600px;"><strong>{{ job.message }}</strong></td>
+                        <td title="{{ job.created|date:'SHORT_DATETIME_FORMAT' }}">{{ job.created|naturaltime }}</td>
+                        <td>
+                            {% if job.started_by %}
+                                {% get_user_name job.started_by %}
+                            {% else %}
+                                Autoreduction Service
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <h3>No failed jobs.</h3>
+            </div>
+        </div>
+    {% endif %} 
+{% endblock %}
+
+{% block scripts %}
+    <script type="text/javascript"> window.CSRF_TOKEN = "{{ csrf_token }}"; </script>
+    <script src='{% static "javascript/fail_queue.js" %}'> </script>
+{% endblock %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/navbar.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/navbar.html
@@ -27,6 +27,9 @@
                     </li>
                     {% if user.is_superuser %}
                     <li>
+                        <a href="{% url 'fail_queue' %}">Failed Jobs</a>
+                    </li>
+                    <li>
                         <a href="{% url 'admin:index' %}">Admin</a>
                     </li>
                     {% endif %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/run_summary.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/run_summary.html
@@ -67,6 +67,24 @@
                                         <em>Not yet finished</em>
                                     {% endif %}
                                 </div>
+                                <div>
+                                    <strong>Retrying:</strong> 
+                                    {% if run.finished %}
+                                        {% if run.retry_when %}
+                                            {{ run.retry_when|naturaltime }}
+                                            {% if run.cancel %}
+                                                <span> (Last attempt)</span>
+                                            {% endif %}
+                                            {% if run.retry_run %}
+                                                <a href="{% url 'run_summary' run_number=run.retry_run.run_number run_version=run.retry_run.run_version %}"> ({{ run.retry_run.status }})</a>
+                                            {% endif %}
+                                        {% else %}
+                                            Never
+                                        {% endif %}
+                                    {% else %}
+                                        <em>Not yet finished</em>
+                                    {% endif %}
+                                </div>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
This adds a page (/runs/failed) to the webapp, allowing for failed runs to be seen, retried, etc. It also checks for file permissions on the backend before running a job, and on failure schedules a job to be rerun in 6 hours. Finally, it notifies isisreduce@stfc.ac.uk of all reduction failures.

This fixes https://github.com/mantidproject/autoreduce/issues/262.