### PR TITLE
Fixed retry_run field

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -42,7 +42,7 @@ class ReductionRun(models.Model):
     graph = SeparatedValuesField(null=True, blank=True)
     hidden_in_failviewer = models.BooleanField(default=False)
     retry_when = models.DateTimeField(null=True, blank=True)
-    retry_run = models.ForeignKey('self', on_delete=models.CASCADE, null=True)
+    retry_run = models.ForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True)
     cancel = models.BooleanField(default=False)
 
     def __unicode__(self):


### PR DESCRIPTION
This is a bugfix for https://github.com/mantidproject/autoreduce/issues/275 - otherwise you can't edit a run without having to set a successor run to it, and deleting a run would have deleted all of its predecessors.