### PR TITLE
279 cancel runs

### DIFF
--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
@@ -86,8 +86,7 @@ class Listener(object):
     def cancelRun(self, data_dict):
         tup = self.runTuple(data_dict)
         self.cancelList.remove(tup) # don't cancel next time
-        data_dict["message"] = "Run cancelled by user"
-        self._client.send(self._conf['postprocess_error'], json.dumps(data_dict)) # send the error back
+        # don't send any message; it'll be handled on the frontend
         
 
 class Consumer(object):

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -4,14 +4,14 @@ import logging
 import logging.config
 logging.config.dictConfig(LOGGING)
 logger = logging.getLogger("django")
-import time, sys, os, json, glob, base64, shutil
+import time, sys, os, json, glob, base64
 from django.utils import timezone
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 sys.path.insert(0, BASE_DIR)
 from reduction_viewer.models import ReductionRun, ReductionLocation, DataLocation, Experiment
-from reduction_viewer.utils import StatusUtils, InstrumentUtils
+from reduction_viewer.utils import StatusUtils, InstrumentUtils, ReductionRunUtils
 from reduction_variables.models import RunVariable
-from reduction_variables.utils import ReductionVariablesUtils, MessagingUtils
+from reduction_variables.utils import MessagingUtils
 from icat_communication import ICATCommunication
 from django.db import connection
 import smtplib
@@ -247,7 +247,7 @@ class Listener(object):
             
         logger.info("Retrying run in %i seconds" % retryIn)
         
-        new_job = ReductionVariablesUtils().createRetryRun(reductionRun, delay=retryIn)          
+        new_job = ReductionRunUtils().createRetryRun(reductionRun, delay=retryIn)          
         try:
             MessagingUtils().send_pending(new_job, delay=retryIn*1000) # seconds to ms
         except Exception as e:

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -3,9 +3,8 @@ sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
 from autoreduce_webapp.settings import ACTIVEMQ, REDUCTION_DIRECTORY, FACILITY
 logger = logging.getLogger('django')
-from django.utils import timezone
 from reduction_variables.models import InstrumentVariable, ScriptFile, RunVariable
-from reduction_viewer.models import ReductionRun, Notification, DataLocation
+from reduction_viewer.models import ReductionRun, Notification
 from reduction_viewer.utils import InstrumentUtils, StatusUtils
 from autoreduce_webapp.icat_communication import ICATCommunication
 
@@ -384,62 +383,7 @@ class ReductionVariablesUtils(object):
         arguments = { 'standard_vars' : standard_vars, 'advanced_vars': advanced_vars }
 
         return (script, arguments)
-      
-                 
-    def createRetryRun(self, reductionRun, scripts=None, variables=None, delay=0):
-        """
-        Create a run ready for re-running based on the run provided. If variables are provided, copy them and associate them with the new one, otherwise generate variables based on the previous run. If ScriptFile objects are supplied, use them, otherwise use the previous run's.
-        """
-        # find the previous run version, so we don't create a duplicate
-        last_version = -1
-        for run in ReductionRun.objects.filter(experiment=reductionRun.experiment, run_number=reductionRun.run_number):
-            last_version = max(last_version, run.run_version)
-            
-        try:
-            # create the run object and save it
-            new_job = ReductionRun(
-                instrument = reductionRun.instrument,
-                run_number = reductionRun.run_number,
-                run_name = "",
-                run_version = last_version+1,
-                experiment = reductionRun.experiment,
-                #started_by=request.user.username, # commented out for the test server only
-                status = StatusUtils().get_queued()
-                )
-            new_job.save()
-            
-            reductionRun.retry_run = new_job
-            reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=delay if delay else 0)
-            reductionRun.save()
-            
-            # copy the previous data locations
-            for data_location in reductionRun.data_location.all():
-                new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)
-                new_data_location.save()
-                new_job.data_location.add(new_data_location)
-                
-            if not variables: # provide variables if they aren't already
-                variables = InstrumentVariablesUtils().get_variables_for_run(new_job)
-            for var in variables:
-                new_var = RunVariable(name=var.name, value=var.value, type=var.type, is_advanced=var.is_advanced, help_text=var.help_text) # copy variable
-                new_var.reduction_run = new_job # associate it with the new run
-                new_job.run_variables.add(new_var)
-                
-                # add scripts based on whether some were supplied
-                if not scripts:
-                    scripts = var.scripts.all()
-                for script in scripts:
-                    new_var.scripts.add(script)
-                    
-                new_var.save()
-                    
-            return new_job
-            
-        except:
-            new_job.delete()
-            raise
         
-
 
 class MessagingUtils(object):
     def send_pending(self, reduction_run, delay=None):

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -6,9 +6,9 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseForbidden
 from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, has_valid_login, handle_redirect
 from reduction_variables.models import InstrumentVariable, RunVariable, ScriptFile
-from reduction_variables.utils import InstrumentVariablesUtils, ReductionVariablesUtils, VariableUtils, MessagingUtils, ScriptUtils
+from reduction_variables.utils import InstrumentVariablesUtils, VariableUtils, MessagingUtils, ScriptUtils
 from reduction_viewer.models import Instrument, ReductionRun
-from reduction_viewer.utils import StatusUtils
+from reduction_viewer.utils import StatusUtils, ReductionRunUtils
 
 import logging, re, json
 logger = logging.getLogger(__name__)
@@ -478,7 +478,7 @@ def run_confirmation(request, instrument):
             if 'error' not in context_dictionary:
                 script.save()
                 script_vars.save()
-                new_job = ReductionVariablesUtils().createRetryRun(old_reduction_run, scripts=[script, script_vars], variables=new_variables)
+                new_job = ReductionRunUtils().createRetryRun(old_reduction_run, scripts=[script, script_vars], variables=new_variables)
 
                 try:
                     MessagingUtils().send_pending(new_job)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
@@ -55,9 +55,12 @@ class ReductionRunUtils(object):
         elif not reductionRun.retry_run: # we don't actually have a rerun, so just ensure the retry time is set to "Never" (None)
             reductionRun.retry_when = None
         
-        elif reductionRun.retry_run.status == StatusUtils().get_queued(): # this run is being queued to retry, so send the message to queueProcessor to cancel it
+        elif reductionRun.retry_run.status == StatusUtils().get_queued(): # this run is being queued to retry, so send the message to queueProcessor to cancel it, and set it as cancelled
             reductionRun.retry_when = None
             MessagingUtils().send_cancel(reductionRun.retry_run)
+            reductionRun.retry_run.message = "Run cancelled by user"
+            reductionRun.retry_run.status = StatusUtils().get_error()
+            reductionRun.retry_run.finished = timezone.now().replace(microsecond=0)
         
         elif reductionRun.retry_run.status == StatusUtils().get_processing(): # we have a run that's retrying, so just make sure it doesn't retry next time
             reductionRun.cancel = True

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
@@ -56,11 +56,11 @@ class ReductionRunUtils(object):
             reductionRun.retry_when = None
         
         elif reductionRun.retry_run.status == StatusUtils().get_queued(): # this run is being queued to retry, so send the message to queueProcessor to cancel it, and set it as cancelled
-            reductionRun.retry_when = None
             MessagingUtils().send_cancel(reductionRun.retry_run)
             reductionRun.retry_run.message = "Run cancelled by user"
             reductionRun.retry_run.status = StatusUtils().get_error()
             reductionRun.retry_run.finished = timezone.now().replace(microsecond=0)
+            reductionRun.retry_run.retry_when = None
         
         elif reductionRun.retry_run.status == StatusUtils().get_processing(): # we have a run that's retrying, so just make sure it doesn't retry next time
             reductionRun.cancel = True

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/utils.py
@@ -1,10 +1,11 @@
-import logging, os, sys
+import logging, os, sys, datetime
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
-from autoreduce_webapp.settings import LOG_FILE, LOG_LEVEL, BASE_DIR
 logger = logging.getLogger(__name__)
-from django.db import models
-from reduction_viewer.models import Instrument, Status
+from django.utils import timezone
+from reduction_viewer.models import Instrument, Status, ReductionRun, DataLocation
+from reduction_variables.models import RunVariable
+from reduction_variables.utils import InstrumentVariablesUtils
 
 class StatusUtils(object):
     def _get_status(self, status_value):
@@ -42,3 +43,60 @@ class InstrumentUtils(object):
             instrument.save()
             logger.warn("%s instrument was not found, created it." % instrument_name)
         return instrument
+        
+class ReductionRunUtils(object):
+    # def cancelRun(self, reductionRun):
+        # undefined
+
+    def createRetryRun(self, reductionRun, scripts=None, variables=None, delay=0):
+        """
+        Create a run ready for re-running based on the run provided. If variables are provided, copy them and associate them with the new one, otherwise generate variables based on the previous run. If ScriptFile objects are supplied, use them, otherwise use the previous run's.
+        """
+        # find the previous run version, so we don't create a duplicate
+        last_version = -1
+        for run in ReductionRun.objects.filter(experiment=reductionRun.experiment, run_number=reductionRun.run_number):
+            last_version = max(last_version, run.run_version)
+            
+        try:
+            # create the run object and save it
+            new_job = ReductionRun(
+                instrument = reductionRun.instrument,
+                run_number = reductionRun.run_number,
+                run_name = "",
+                run_version = last_version+1,
+                experiment = reductionRun.experiment,
+                #started_by=request.user.username, # commented out for the test server only
+                status = StatusUtils().get_queued()
+                )
+            new_job.save()
+            
+            reductionRun.retry_run = new_job
+            reductionRun.retry_when = timezone.now().replace(microsecond=0) + datetime.timedelta(seconds=delay if delay else 0)
+            reductionRun.save()
+            
+            # copy the previous data locations
+            for data_location in reductionRun.data_location.all():
+                new_data_location = DataLocation(file_path=data_location.file_path, reduction_run=new_job)
+                new_data_location.save()
+                new_job.data_location.add(new_data_location)
+                
+            if not variables: # provide variables if they aren't already
+                variables = InstrumentVariablesUtils().get_variables_for_run(new_job)
+            for var in variables:
+                new_var = RunVariable(name=var.name, value=var.value, type=var.type, is_advanced=var.is_advanced, help_text=var.help_text) # copy variable
+                new_var.reduction_run = new_job # associate it with the new run
+                new_job.run_variables.add(new_var)
+                
+                # add scripts based on whether some were supplied
+                if not scripts:
+                    scripts = var.scripts.all()
+                for script in scripts:
+                    new_var.scripts.add(script)
+                    
+                new_var.save()
+                    
+            return new_job
+            
+        except:
+            new_job.delete()
+            raise

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -8,9 +8,9 @@ from autoreduce_webapp.uows_client import UOWSClient
 from autoreduce_webapp.icat_communication import ICATCommunication
 from autoreduce_webapp.settings import UOWS_LOGIN_URL
 from reduction_viewer.models import Experiment, ReductionRun, Instrument
-from reduction_viewer.utils import StatusUtils
+from reduction_viewer.utils import StatusUtils, ReductionRunUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
-from reduction_variables.utils import MessagingUtils, ReductionVariablesUtils
+from reduction_variables.utils import MessagingUtils
 from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_admin
 import operator
 import json
@@ -111,7 +111,7 @@ def fail_queue(request):
                         continue # do not run multiples of the same run
                 
                     reductionRun.cancel = False
-                    new_job = ReductionVariablesUtils().createRetryRun(reductionRun)
+                    new_job = ReductionRunUtils().createRetryRun(reductionRun)
                     
                     try:
                         MessagingUtils().send_pending(new_job)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -110,6 +110,7 @@ def fail_queue(request):
                     if runVersion != highest_version:
                         continue # do not run multiples of the same run
                 
+                    ReductionRunUtils().cancelRun(reductionRun)    
                     reductionRun.cancel = False
                     new_job = ReductionRunUtils().createRetryRun(reductionRun)
                     
@@ -121,12 +122,7 @@ def fail_queue(request):
                     
                         
                 elif action == "cancel":
-                    reductionRun.cancel = True
-                    reductionRun.save()
-                    
-                    if reductionRun.retry_run:
-                        reductionRun.retry_run.cancel = True
-                        reductionRun.retry_run.save()
+                    ReductionRunUtils().cancelRun(reductionRun)                       
                        
                        
                 elif action == "default":

--- a/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/fail_queue.html
@@ -23,7 +23,7 @@
                     <option value="default">Select action to apply to selected runs</option>
                     <option value="rerun">Re-run </option>
                     <option value="hide">Hide </option>
-                    <option value="cancel">Stop retrying</option>
+                    <option value="cancel">Cancel retry</option>
                 </select>
                 <form id="actionForm" method="POST" action="{% url 'fail_queue' %}" style="float: left; padding-left: 5px;">
                     <input type='hidden' name='csrfmiddlewaretoken' value='{{ csrf_token }}' />


### PR DESCRIPTION
Fixes https://github.com/mantidproject/autoreduce/issues/279

There is now a menu option in the failed jobs viewer to cancel retries; this will set a retry job, if there is one, to 'error' status with message "Run cancelled by user". It sends a message to the backend queueProcessor, which keeps a list of runs that will be cancelled in the future.

To test
* Try to cancel a run without any retry, or one that's already completed; nothing should happen.
* Try to cancel a run that's scheduled to be retried in the future; the retry run should not run on the backend, and should immediately be set to failed on the frontend.