### PR TITLE
Moving email settings to settings.py

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -1,5 +1,5 @@
 import stomp
-from settings import ACTIVEMQ, BASE_DIR, LOGGING, ERROR_EMAILS
+from settings import ACTIVEMQ, BASE_DIR, LOGGING, EMAIL_HOST, EMAIL_PORT, EMAIL_ERROR_RECIPIENTS, EMAIL_ERROR_SENDER, BASE_URL
 import logging
 import logging.config
 logging.config.dictConfig(LOGGING)
@@ -231,21 +231,24 @@ class Listener(object):
         
     def notifyRunFailure(self, reductionRun):
     
-        receivers = filter(lambda addr: addr.split('@')[-1] != 'autoreduce.isis.rl.ac.uk', ERROR_EMAILS) # don't send local emails
+        recipients = EMAIL_ERROR_RECIPIENTS
+        localRecipients = filter(lambda addr: addr.split('@')[-1] == BASE_URL, recipients) # this does not parse esoteric (but RFC-compliant) email addresses correctly
+        if localRecipients: # don't send local emails
+            raise Exception("Local email address specified in ERROR_EMAILS - %s match %s" % (localRecipients, BASE_URL))
     
-        senderAddress = "autoreduce@reducedev.isis.cclrc.ac.uk"
+        senderAddress = EMAIL_ERROR_SENDER
         
         errorMsg = "A reduction run - experiment %s, run %s, version %s - has failed:\n%s\n\n" % (reductionRun.experiment.reference_number, reductionRun.run_number, reductionRun.run_version, reductionRun.message)
         errorMsg += "The run will not retry automatically.\n" if not reductionRun.retry_when else "The run will automatically retry on %s.\n" % reductionRun.retry_when
-        errorMsg += "Retry manually at http://reducedev.isis.cclrc.ac.uk/runs/%i/%i/ or on %s." % (reductionRun.run_number, reductionRun.run_version, "http://reducedev.isis.cclrc.ac.uk/runs/failed/")
+        errorMsg += "Retry manually at %s/%i/%i/ or on %s/runs/failed/." % (BASE_URL, reductionRun.run_number, reductionRun.run_version, BASE_URL)
         
-        emailContent = "From: %s\nTo: %s\nSubject:Autoreduction error\n\n%s" % (senderAddress, ", ".join(receivers), errorMsg)
+        emailContent = "From: %s\nTo: %s\nSubject:Autoreduction error\n\n%s" % (senderAddress, ", ".join(recipients), errorMsg)
 
         logger.info("Sending email: %s" % emailContent)
                        
         try:
-            s = smtplib.SMTP('exchsmtp.stfc.ac.uk', 25)
-            s.sendmail(senderAddress, receivers, emailContent)
+            s = smtplib.SMTP(EMAIL_HOST, EMAIL_PORT)
+            s.sendmail(senderAddress, recipients, emailContent)
             s.close()
         except Exception as e:
             logger.error("Failed to send emails %s" % emailContent)

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/queue_processor.py
@@ -240,7 +240,7 @@ class Listener(object):
         
         errorMsg = "A reduction run - experiment %s, run %s, version %s - has failed:\n%s\n\n" % (reductionRun.experiment.reference_number, reductionRun.run_number, reductionRun.run_version, reductionRun.message)
         errorMsg += "The run will not retry automatically.\n" if not reductionRun.retry_when else "The run will automatically retry on %s.\n" % reductionRun.retry_when
-        errorMsg += "Retry manually at %s/%i/%i/ or on %s/runs/failed/." % (BASE_URL, reductionRun.run_number, reductionRun.run_version, BASE_URL)
+        errorMsg += "Retry manually at %s%i/%i/ or on %sruns/failed/." % (BASE_URL, reductionRun.run_number, reductionRun.run_version, BASE_URL)
         
         emailContent = "From: %s\nTo: %s\nSubject:Autoreduction error\n\n%s" % (senderAddress, ", ".join(recipients), errorMsg)
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -181,7 +181,9 @@ UOWS_LOGIN_URL = 'https://devusers.facilities.rl.ac.uk/auth/?service=http://data
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'exchsmtp.stfc.ac.uk'
 EMAIL_PORT = 25
-ERROR_EMAILS = ['isisreduce@stfc.ac.uk']
+EMAIL_ERROR_RECIPIENTS = ['isisreduce@stfc.ac.uk']
+EMAIL_ERROR_SENDER = 'autoreduce@reducedev.isis.cclrc.ac.uk'
+BASE_URL = 'http://reducedev.isis.cclrc.ac.uk/'
 
 # Constant vars
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -182,8 +182,8 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'exchsmtp.stfc.ac.uk'
 EMAIL_PORT = 25
 EMAIL_ERROR_RECIPIENTS = ['isisreduce@stfc.ac.uk']
-EMAIL_ERROR_SENDER = 'autoreduce@reducedev.isis.cclrc.ac.uk'
-BASE_URL = 'http://reducedev.isis.cclrc.ac.uk/'
+EMAIL_ERROR_SENDER = 'autoreduce@reduce.isis.cclrc.ac.uk'
+BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 
 # Constant vars
 


### PR DESCRIPTION
Fixes https://github.com/mantidproject/autoreduce/issues/281

To test, run a job that fails. An email should be sent that looks like, e.g.,
```
From: autoreduce@reducedev.isis.cclrc.ac.uk
To: isisreduce@stfc.ac.uk
Subject: Autoreduction error

A reduction run - experiment 1610459, run 35690, version 32 - has failed:
REDUCTION Error: [Errno 13] Permission denied: '/reducedev/instrument' 

The run will automatically retry on 2016-07-28 10:49:28+00:00.
Retry manually at http://reduce.isis.cclrc.ac.uk/35690/32/ or on http://reduce.isis.cclrc.ac.uk/runs/failed/.
```