### PR TITLE
252 speedup index

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -16,7 +16,7 @@ urlpatterns = patterns('',
     url(r'^runs/$', reduction_viewer_views.run_list, name='run_list'),   
     url(r'^runs/queue/$', reduction_viewer_views.run_queue, name='run_queue'), 
     url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'),
-    url(r'^runs/list/(?P<rb_number>[0-9]+)/$', reduction_viewer_views.load_runs, name='load_runs'),
+    url(r'^runs/list/(?P<reference_number>[0-9]+)/$', reduction_viewer_views.load_runs, name='load_runs'),
     url(r'^runs/(?P<run_number>[0-9]+)(?:/(?P<run_version>[0-9]+))?/$', reduction_viewer_views.run_summary, name='run_summary'),
     url(r'^runs/(?P<instrument>\w+)/confirmation/$', reduction_variables_views.run_confirmation, name='run_confirmation'),
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -15,7 +15,8 @@ urlpatterns = patterns('',
 
     url(r'^runs/$', reduction_viewer_views.run_list, name='run_list'),   
     url(r'^runs/queue/$', reduction_viewer_views.run_queue, name='run_queue'), 
-    url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'), 
+    url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'),
+    url(r'^runs/list/(?P<rb_number>[0-9]+)/$', reduction_viewer_views.load_runs, name='load_runs'),
     url(r'^runs/(?P<run_number>[0-9]+)(?:/(?P<run_version>[0-9]+))?/$', reduction_viewer_views.run_summary, name='run_summary'),
     url(r'^runs/(?P<instrument>\w+)/confirmation/$', reduction_variables_views.run_confirmation, name='run_confirmation'),
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/urls.py
@@ -17,6 +17,7 @@ urlpatterns = patterns('',
     url(r'^runs/queue/$', reduction_viewer_views.run_queue, name='run_queue'), 
     url(r'^runs/failed/$', reduction_viewer_views.fail_queue, name='fail_queue'),
     url(r'^runs/list/(?P<reference_number>[0-9]+)/$', reduction_viewer_views.load_runs, name='load_runs'),
+    url(r'^runs/list/(?P<instrument_name>\w+)/$', reduction_viewer_views.load_runs, name='load_runs'),
     url(r'^runs/(?P<run_number>[0-9]+)(?:/(?P<run_version>[0-9]+))?/$', reduction_viewer_views.run_summary, name='run_summary'),
     url(r'^runs/(?P<instrument>\w+)/confirmation/$', reduction_variables_views.run_confirmation, name='run_confirmation'),
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -250,15 +250,17 @@ def run_list(request):
     
 @login_and_uows_valid
 @render_with('load_runs.html')
-def load_runs(request, rb_number):
-    experiments = Experiment.objects.filter(rb_number=rb_number)
-    if length(experiments) == 0:
+def load_runs(request, reference_number):
+    context_dictionary = {}
+    experiments = Experiment.objects.filter(reference_number=reference_number)
+    if len(experiments) == 0:
         context_dictionary['no_runs'] = True
     else:
+        experiment = experiments[0]
         runs = ReductionRun.objects.filter(experiment=experiment).order_by('-created')
-        if length(runs) == 0:
+        if len(runs) == 0:
             context_dictionary['no_runs'] = True
-        else
+        else:
             context_dictionary['no_runs'] = False
             context_dictionary['runs'] = runs
             

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -247,6 +247,24 @@ def run_list(request):
 
     return context_dictionary
 
+    
+@login_and_uows_valid
+@render_with('load_runs.html')
+def load_runs(request, rb_number):
+    experiments = Experiment.objects.filter(rb_number=rb_number)
+    if length(experiments) == 0:
+        context_dictionary['no_runs'] = True
+    else:
+        runs = ReductionRun.objects.filter(experiment=experiment).order_by('-created')
+        if length(runs) == 0:
+            context_dictionary['no_runs'] = True
+        else
+            context_dictionary['no_runs'] = False
+            context_dictionary['runs'] = runs
+            
+    return context_dictionary
+
+    
 @login_and_uows_valid
 @render_with('run_summary.html')
 def run_summary(request, run_number, run_version=0):

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -46,8 +46,9 @@
     };
     
     var load_all_runs = function load_all_runs(event) {
-        $(".js-toggle-experiment-children").click(); // trigger loading of all unloaded runs
-        $(".js-toggle-experiment-children").click(); // click again to reset open/closed status
+        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // trigger loading of all unloaded runs
+        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // click again to reset open/closed status
+        
         $('#run_search').prop('onfocus',null).off('focus'); // unregister load trigger
     };
 
@@ -124,19 +125,20 @@ function expandItem(el) {
     // indicate that we're loading
     expandItem.counter++;
     $("*").css("cursor", "wait");
-    $("#run_search").addClass("has-warning");
+    $("#search-parent").addClass("has-warning");
+    
+    // unregister the load trigger
+    $(el).prop('onclick',null).off('click');
         
     var name = el.id;
     $("#"+name+"-list").load("list/"+name, 
         function () {
-            $(el).prop('onclick',null).off('click');
-            expandItem.counter--;
-            
             // remove loading indicators if we should
+            expandItem.counter--;
             if (expandItem.counter <= 0)
             {
                 $("*").css("cursor", "default");
-                $("#run_search").removeClass("has-warning");
+                $("#search-parent").removeClass("has-warning");
             }
         });
 };

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -44,6 +44,12 @@
             $(this).parents('.experiment').find('.experiment-runs').toggleClass('hide');
         }
     };
+    
+    var load_all_runs = function load_all_runs(event) {
+        $(".js-toggle-experiment-children").click(); // trigger loading of all unloaded runs
+        $(".js-toggle-experiment-children").click(); // click again to reset open/closed status
+        $('#run_search').prop('onfocus',null).off('focus'); // unregister load trigger
+    };
 
     var run_search = function run_search(event){
         if((event.keyCode || event.which || event.charCode) === 13){
@@ -100,6 +106,7 @@
         }
 
         $('#run_search').on('keyup', run_search).popover();
+        $('#run_search').on('focus', load_all_runs); // load all items
         $('#by-run-number-tab a,#by-experiment-tab a').on('click', tabClickAction);
         $('#by-tabs-mobile').on('change', mobileTabChangeAction);
         $('.instrument-heading').on('click', toggleInstrumentsExperimentsClickAction)
@@ -108,3 +115,15 @@
 
     init();
 }());
+
+
+// Put this in the global namespace for various snippets to use.
+function expandItem(el) {
+    var name = el.id;
+    $("*").css("cursor", "wait");
+    $("#"+name+"-list").load("list/"+name, 
+        function () {
+            $("*").css("cursor", "default");
+            $(el).prop('onclick',null).off('click');
+        });
+};

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -109,8 +109,8 @@
         $('#run_search').on('focus', load_all_runs); // load all items
         $('#by-run-number-tab a,#by-experiment-tab a').on('click', tabClickAction);
         $('#by-tabs-mobile').on('change', mobileTabChangeAction);
-        $('.instrument-heading').on('click', toggleInstrumentsExperimentsClickAction)
-        $('.experiment-heading').on('click', toggleExperimentRunsClickAction)
+        $('.instrument-heading').on('click', toggleInstrumentsExperimentsClickAction);
+        $('.experiment-heading').on('click', toggleExperimentRunsClickAction);
     };
 
     init();
@@ -119,11 +119,24 @@
 
 // Put this in the global namespace for various snippets to use.
 function expandItem(el) {
-    var name = el.id;
+    expandItem.counter = expandItem.counter || 0; // keep track of how many items we're currently loading
+    
+    // indicate that we're loading
+    expandItem.counter++;
     $("*").css("cursor", "wait");
+    $("#run_search").addClass("has-warning");
+        
+    var name = el.id;
     $("#"+name+"-list").load("list/"+name, 
         function () {
-            $("*").css("cursor", "default");
             $(el).prop('onclick',null).off('click');
+            expandItem.counter--;
+            
+            // remove loading indicators if we should
+            if (expandItem.counter <= 0)
+            {
+                $("*").css("cursor", "default");
+                $("#run_search").removeClass("has-warning");
+            }
         });
 };

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -39,7 +39,7 @@
     };
     var toggleExperimentRunsClickAction = function toggleExperimentRunsClickAction(event){
         var $target = $(event.target);
-        if(($target.is('a') && $target.attr('href')==='#') || ($target.parent().is('a') && $target.parent().attr('href')==='#') || $target.is(':not(a)') && ($.target.parent().is(':not(a)'))){
+        if(($target.is('a') && $target.attr('href')==='#') || ($target.parent().is('a') && $target.parent().attr('href')==='#') || $target.is(':not(a)') && ($target.parent().is(':not(a)'))){
             $(this).find("i[class*='fa-chevron']").toggleClass('fa-chevron-right fa-chevron-down');
             $(this).parents('.experiment').find('.experiment-runs').toggleClass('hide');
         }

--- a/WebApp/ISIS/autoreduce_webapp/templates/load_runs.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/load_runs.html
@@ -1,0 +1,11 @@
+{% block body %}
+    {% if not no_runs %}
+        {% for run in runs %}
+            {% include "snippets/run_table.html" with run=run only %}
+        {% endfor %}
+    {% else %}
+        <div class="row">
+            <div class="col-md-12 text-center no-results">No runs found.</div>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/load_runs.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/load_runs.html
@@ -1,5 +1,5 @@
 {% block body %}
-    {% if not no_runs %}
+    {% if runs %}
         {% for run in runs %}
             {% include "snippets/run_table.html" with run=run only %}
         {% endfor %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
@@ -6,7 +6,7 @@
         <title>ISIS Auto-reduction</title>
         <div class="row">
             <div class="col-md-12">
-                <div class="form-group">
+                <div class="form-group" id="search-parent">
                     <label for="run_search" class="screenreader-only">Search</label>
                     <input type="search" placeholder="Search" name="run_search" id="run_search" class="form-control" autocomplete="off" data-toggle="popover" data-trigger="focus" data-content="Try entering an RB number or run number." data-placement="top">
                 </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
@@ -1,6 +1,14 @@
+<script>
+function expandExperiment(el) {
+    var rb_number = el.id;
+    $("*").css("cursor", "wait");
+    $(rb_number+"-list").load(rb_number, function () {$("*").css("cursor", "default");})
+};
+</script>
+
 <div class="row experiment-heading">
     <div class="col-md-1 col-xs-1">
-        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse"><i class="fa fa-lg fa-chevron-right"></i></a>
+        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse" id="{{ experiment.reference_number }}" onclick="expandExperiment(this);"><i class="fa fa-lg fa-chevron-right"></i></a>
     </div>
     <div class="col-md-11 col-xs-10">
         <a href="{% url 'experiment_summary' experiment.reference_number %}">{{ experiment.reference_number }}</a>
@@ -17,14 +25,5 @@
         </div>
     </div>
 </div>
-<div class="experiment-runs hide">
-    {% if experiment.runs %}
-        {% for run in experiment.runs %}
-            {% include "snippets/run_table.html" with run=run only %}
-        {% endfor %}
-    {% else %}
-        <div class="row">
-            <div class="col-md-12 text-center no-results">No runs found.</div>
-        </div>
-    {% endif %}
+<div class="experiment-runs hide" id="{{ experiment.reference_number }}-list" >
 </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
@@ -2,7 +2,11 @@
 function expandExperiment(el) {
     var rb_number = el.id;
     $("*").css("cursor", "wait");
-    $(rb_number+"-list").load(rb_number, function () {$("*").css("cursor", "default");})
+    $("#"+rb_number+"-list").load("list/"+rb_number, 
+        function () {
+            $("*").css("cursor", "default");
+            $(el).prop('onclick',null).off('click');
+        })
 };
 </script>
 

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
@@ -1,18 +1,6 @@
-<script>
-function expandExperiment(el) {
-    var rb_number = el.id;
-    $("*").css("cursor", "wait");
-    $("#"+rb_number+"-list").load("list/"+rb_number, 
-        function () {
-            $("*").css("cursor", "default");
-            $(el).prop('onclick',null).off('click');
-        })
-};
-</script>
-
 <div class="row experiment-heading">
     <div class="col-md-1 col-xs-1">
-        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse" id="{{ experiment.reference_number }}" onclick="expandExperiment(this);"><i class="fa fa-lg fa-chevron-right"></i></a>
+        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse" id="{{ experiment.reference_number }}" onclick="expandItem(this);"><i class="fa fa-lg fa-chevron-right"></i></a>
     </div>
     <div class="col-md-11 col-xs-10">
         <a href="{% url 'experiment_summary' experiment.reference_number %}">{{ experiment.reference_number }}</a>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
@@ -39,21 +39,21 @@
         </div>
     </div>
     {% if by == "experiment" %}
-        <div class="experiment hide">
-            {% if instrument.experiments %}
-                {% for experiment in instrument.experiments %}
-                    <div class="experiment hide">
-                        {% include "snippets/experiment_table.html" with experiment=experiment only %}
-                    </div>
-                {% endfor %}
-            {% else %}
-                <div class="row">
-                    <div class="col-md-12 text-center no-results">
-                        No experiments found.
-                    </div>
+        {% if instrument.experiments %}
+            {% for experiment in instrument.experiments %}
+                <div class="experiment hide">
+                    {% include "snippets/experiment_table.html" with experiment=experiment only %}
                 </div>
-            {% endif %}
-        </div>
+            {% endfor %}
+        {% else %}
+            <div class="experiment hide">
+                    <div class="row">
+                        <div class="col-md-12 text-center no-results">
+                            No experiments found.
+                        </div>
+                    </div>
+            </div>
+        {% endif %}
     {% elif by == "run" %}
         <div class="run hide" id="{{ instrument.name }}-list" >
         </div>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
@@ -2,7 +2,7 @@
     <div class="row instrument-heading bg-info">
         <div class="col-sm-7 col-xs-12">
             <div class="col-xs-1">
-                <a href="#" class="js-toggle-instrument-children" title="Expand/Collapse"><i id="chevron" class="fa fa-lg fa-chevron-right"></i></a>
+                <a href="#" class="js-toggle-instrument-children" title="Expand/Collapse" id="{{ instrument.name }}" {% if by == "run" %} onclick="expandItem(this);" {% endif %}><i id="chevron" class="fa fa-lg fa-chevron-right"></i></a>
             </div>
             <div class="col-xs-11">
                 {% if instrument.is_active %}
@@ -39,34 +39,23 @@
         </div>
     </div>
     {% if by == "experiment" %}
-        {% if instrument.experiments %}
+        <div class="experiment hide">
+            {% if instrument.experiments %}
                 {% for experiment in instrument.experiments %}
                     <div class="experiment hide">
                         {% include "snippets/experiment_table.html" with experiment=experiment only %}
                     </div>
                 {% endfor %}
-        {% else %}
-            <div class="experiment hide">
+            {% else %}
                 <div class="row">
                     <div class="col-md-12 text-center no-results">
                         No experiments found.
                     </div>
                 </div>
-            </div>
-        {% endif %}
-    {% elif by == "run" %}
-        <div class="run hide">
-            {% if instrument.runs %}
-                {% for run in instrument.runs %}
-                    {% include "snippets/run_table.html" with run=run only %}
-                {% endfor %}
-            {% else %}
-                <div class="row">
-                    <div class="col-md-12 text-center no-results">
-                        No runs found.
-                    </div>
-                </div>
             {% endif %}
+        </div>
+    {% elif by == "run" %}
+        <div class="run hide" id="{{ instrument.name }}-list" >
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Fixes https://github.com/mantidproject/autoreduce/issues/252

The problem is that Django struggles to render the HTML for all the runs when there are thousands of them. I modified the main run list page to only load a list of instruments and experiments, instead of loading all runs at once. When a user expands one of these tabs, the client queries the server for a list of runs to display, and Django renders only the runs needed then. When a user wants to search all runs by clicking on the search bar, all runs are loaded. Each tab is only loaded once.

The production server is patched to use this, since the dev server doesn't have enough runs to show slowdown. To test,
* visit the main page and check that loading it doesn't take ages (10 seconds or more)
* check that expanding a tab shows the correct runs beneath it
* check that the search bar will (eventually) show all results when used