### PR TITLE
293 index issues

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -193,4 +193,4 @@ BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 # Constant vars
 
 FACILITY = "ISIS"
-PRELOAD_RUNS_UNDER = 0#100 # If the index run list has fewer than this many runs to show the user, preload them all.
+PRELOAD_RUNS_UNDER = 100 # If the index run list has fewer than this many runs to show the user, preload them all.

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -193,3 +193,4 @@ BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 # Constant vars
 
 FACILITY = "ISIS"
+PRELOAD_RUNS_UNDER = 100 # If the index run list has fewer than this many runs to show the user, preload them all.

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -193,4 +193,4 @@ BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 # Constant vars
 
 FACILITY = "ISIS"
-PRELOAD_RUNS_UNDER = 100 # If the index run list has fewer than this many runs to show the user, preload them all.
+PRELOAD_RUNS_UNDER = 0#100 # If the index run list has fewer than this many runs to show the user, preload them all.

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -44,6 +44,32 @@
             $(this).parents('.experiment').find('.experiment-runs').toggleClass('hide');
         }
     };
+    
+    function expandItem(event) {
+        el = event.currentTarget;
+        
+        expandItem.counter = expandItem.counter || 0; // keep track of how many items we're currently loading
+        
+        // indicate that we're loading
+        expandItem.counter++;
+        $("*").css("cursor", "wait");
+        $("#search-parent").addClass("has-warning");
+        
+        // unregister the load trigger
+        $(el).off('click', expandItem);
+            
+        var name = el.id;
+        $("#"+name+"-list").load("list/"+name, 
+            function () {
+                // remove loading indicators if we should
+                expandItem.counter--;
+                if (expandItem.counter <= 0)
+                {
+                    $("*").css("cursor", "default");
+                    $("#search-parent").removeClass("has-warning");
+                }
+            });
+    };
 
     var run_search = function run_search(event){
         if((event.keyCode || event.which || event.charCode) === 13){
@@ -87,6 +113,13 @@
             $('#no-search-results').removeClass('hide').show();
         }
     };
+    
+    var load_all_runs = function load_all_runs(event) {
+        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // trigger loading of all unloaded runs
+        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // click again to reset open/closed status
+        
+        $('#run_search').off('focus', load_all_runs); // unregister load trigger
+    };
 
     var mobileOnly = function mobileOnly(){
         $('#run_search').data('placement', 'top');
@@ -103,44 +136,16 @@
         $('#run_search').on('focus', load_all_runs); // load all items
         $('#by-run-number-tab a,#by-experiment-tab a').on('click', tabClickAction);
         $('#by-tabs-mobile').on('change', mobileTabChangeAction);
+        
         $('.instrument-heading').on('click', toggleInstrumentsExperimentsClickAction);
-        $('.experiment-heading').on('click', toggleExperimentRunsClickAction);
+        $('.js-instrument-loader').on('click', expandItem); // should only be attributed to these that are in the 'by run number' tab.
+        $('.experiment-heading').on('click', toggleExperimentRunsClickAction).on('click', expandItem);
+        
+        if (window.preload_runs)
+        {
+            load_all_runs(null);
+        }
     };
 
     init();
 }());
-
-
-
-/// Put these in the global namespace for various snippets to use.
-
-function expandItem(el) {
-    expandItem.counter = expandItem.counter || 0; // keep track of how many items we're currently loading
-    
-    // indicate that we're loading
-    expandItem.counter++;
-    $("*").css("cursor", "wait");
-    $("#search-parent").addClass("has-warning");
-    
-    // unregister the load trigger
-    $(el).prop('onclick',null).off('click');
-        
-    var name = el.id;
-    $("#"+name+"-list").load("list/"+name, 
-        function () {
-            // remove loading indicators if we should
-            expandItem.counter--;
-            if (expandItem.counter <= 0)
-            {
-                $("*").css("cursor", "default");
-                $("#search-parent").removeClass("has-warning");
-            }
-        });
-};
-
-var load_all_runs = function load_all_runs(event) {
-    $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // trigger loading of all unloaded runs
-    $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // click again to reset open/closed status
-    
-    $('#run_search').prop('onfocus',null).off('focus'); // unregister load trigger
-};

--- a/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
+++ b/WebApp/ISIS/autoreduce_webapp/static/javascript/run_list.js
@@ -44,13 +44,6 @@
             $(this).parents('.experiment').find('.experiment-runs').toggleClass('hide');
         }
     };
-    
-    var load_all_runs = function load_all_runs(event) {
-        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // trigger loading of all unloaded runs
-        $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // click again to reset open/closed status
-        
-        $('#run_search').prop('onfocus',null).off('focus'); // unregister load trigger
-    };
 
     var run_search = function run_search(event){
         if((event.keyCode || event.which || event.charCode) === 13){
@@ -118,7 +111,9 @@
 }());
 
 
-// Put this in the global namespace for various snippets to use.
+
+/// Put these in the global namespace for various snippets to use.
+
 function expandItem(el) {
     expandItem.counter = expandItem.counter || 0; // keep track of how many items we're currently loading
     
@@ -141,4 +136,11 @@ function expandItem(el) {
                 $("#search-parent").removeClass("has-warning");
             }
         });
+};
+
+var load_all_runs = function load_all_runs(event) {
+    $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // trigger loading of all unloaded runs
+    $(".js-toggle-experiment-children,.js-toggle-instrument-children").click(); // click again to reset open/closed status
+    
+    $('#run_search').prop('onfocus',null).off('focus'); // unregister load trigger
 };

--- a/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
@@ -54,10 +54,11 @@
     {% endif %} 
 {% endblock %}
 
-{% block scripts %}
+{% block scripts %}    
+    {% if preload_runs %}
+        <script>window.preload_runs = true;</script>
+    {% endif %}
     <script src="{% static "javascript/vendor/fastdom.js" %}"></script>
     <script src="{% static "javascript/run_list.js" %}"></script>
-    {% if preload_runs %}
-        <script>load_all_runs(null);</script>
-    {% endif %}
+
 {% endblock %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/run_list.html
@@ -57,4 +57,7 @@
 {% block scripts %}
     <script src="{% static "javascript/vendor/fastdom.js" %}"></script>
     <script src="{% static "javascript/run_list.js" %}"></script>
+    {% if preload_runs %}
+        <script>load_all_runs(null);</script>
+    {% endif %}
 {% endblock %}

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/experiment_table.html
@@ -1,6 +1,6 @@
-<div class="row experiment-heading">
+<div class="row experiment-heading" id="{{ experiment.reference_number }}">
     <div class="col-md-1 col-xs-1">
-        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse" id="{{ experiment.reference_number }}" onclick="expandItem(this);"><i class="fa fa-lg fa-chevron-right"></i></a>
+        <a href="#" class="js-toggle-experiment-children" title="Expand/Collapse"><i class="fa fa-lg fa-chevron-right"></i></a>
     </div>
     <div class="col-md-11 col-xs-10">
         <a href="{% url 'experiment_summary' experiment.reference_number %}">{{ experiment.reference_number }}</a>

--- a/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
+++ b/WebApp/ISIS/autoreduce_webapp/templates/snippets/instrument_table.html
@@ -1,8 +1,8 @@
 <div class="instrument col-md-12">
-    <div class="row instrument-heading bg-info">
+    <div class="row instrument-heading bg-info {% if by == "run" %} js-instrument-loader {% endif %}" id="{{ instrument.name }}">
         <div class="col-sm-7 col-xs-12">
             <div class="col-xs-1">
-                <a href="#" class="js-toggle-instrument-children" title="Expand/Collapse" id="{{ instrument.name }}" {% if by == "run" %} onclick="expandItem(this);" {% endif %}><i id="chevron" class="fa fa-lg fa-chevron-right"></i></a>
+                <a href="#" class="js-toggle-instrument-children " title="Expand/Collapse"><i id="chevron" class="fa fa-lg fa-chevron-right"></i></a>
             </div>
             <div class="col-xs-11">
                 {% if instrument.is_active %}


### PR DESCRIPTION
Fixes https://github.com/mantidproject/autoreduce/issues/293

I moved the load trigger to where it should be, and added a preload setting that will load all runs when there are less than `PRELOAD_RUNS_UNDER` to show.

To test, on the production server:
* Test that the index run list loads all runs as it is, after the page renders but without any additional interaction.
* Temporarily set `PRELOAD_RUNS_UNDER` to `0`, and check that no tab can be expanded without the corresponding runs being loaded with it.