### PR TITLE
255 user permissions

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -194,3 +194,4 @@ BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 
 FACILITY = "ISIS"
 PRELOAD_RUNS_UNDER = 100 # If the index run list has fewer than this many runs to show the user, preload them all.
+USER_ACCESS_CHECKS = True # Should the webapp prevent users from accessing runs/instruments they're not allowed to?

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -102,7 +102,7 @@ def delete_instrument_variables(request, instrument, start=0, end=0, experiment_
 @render_with('instrument_variables.html')
 def instrument_variables(request, instrument, start=0, end=0, experiment_reference=0):
     # Check the user has permission
-    if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
+    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument not in request.session['owned_instruments']:
         raise PermissionDenied()
     
     instrument = Instrument.objects.get(name=instrument)
@@ -259,7 +259,7 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 @render_with('submit_runs.html')
 def submit_runs(request, instrument):
     # Check the user has permission
-    if not request.user.is_superuser and instrument not in request.session['owned_instruments']:
+    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument not in request.session['owned_instruments']:
         raise PermissionDenied()
 
     instrument = Instrument.objects.get(name=instrument)


### PR DESCRIPTION
Fixes https://github.com/mantidproject/autoreduce/issues/255, https://github.com/mantidproject/autoreduce/issues/269

* The checks that were removed are necessary to stop users accessing runs etc. that they shouldn't, so they're re-enabled. If more issues come up with them and they're not necessary, there's now a setting - `USER_ACCESS_CHECKS` - which can be set to `False` in the settings to disable them.
* The way ICAT was queried was actually correct; on the development server, the UOWS backend was disabled, but on production authentication with UOWS `sessionID` really does work. So this is unchanged. 

To test:
* Log in as the test user `isisreduce@stfc.ac.uk` on the production server and ensure that no runs or instruments are accessible at all.
* Temporarily change the setting `USER_ACCESS_CHECKS` to `False` and check that this user can now see and modify runs and instruments.