### PR TITLE
268 setup scripts

### DIFF
--- a/ISISPostProcessRPM/README.md
+++ b/ISISPostProcessRPM/README.md
@@ -1,6 +1,33 @@
 # Autoreduction setup at ISIS
 
-## Red Hat 7
+## Red Hat 7 - automated installation
+
+The install script will prompt for an ActiveMQ keystore password at the start of the installation, but otherwise will run by itself.
+
+    sudo -i
+    cd ~
+    git clone https://github.com/mantidproject/autoreduce.git
+    ./autoreduce/ISISPostProcessRPM/setup.sh
+    
+After it has run, 
+
+1. ActiveMQ credentials should be changed in `/opt/activemq/conf/activemq.xml` - in the `<authenticationUser>` tag - and in `/etc/autoreduce/post_process_consumer.conf`.
+
+2. ActiveMQ can be started by running `/opt/activemq/bin/activemq start` and the monitor by `python /usr/bin/statusMonitor_daemon.py start`. These expect to run as root.
+
+3. The queue processor can be started by `python /usr/bin/queueProcessor_daemon.py start`; by default the setup expects this to be run as the user `ISISautoreduce@fed.cclrc.ac.uk`.
+
+4. The setup can be tested by
+
+        cd ~/autoreduce/ISISPostProcessRPM/rpmbuild/autoreduce-mq/test
+        nano testconfig.py # Enter the correct address and credentials for ActiveMQ
+        python stompActiveMQtest.py
+        python sendMessage.py
+
+    The first test should exit after printing `received a message`, and the second should put a message into ActiveMQ's queue.
+
+
+## Red Hat 7 - manual (old)
 
 First install Mantid using: http://download.mantidproject.org/redhat.html
 

--- a/ISISPostProcessRPM/isis-rhel.repo
+++ b/ISISPostProcessRPM/isis-rhel.repo
@@ -1,0 +1,27 @@
+[isis-rhel]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-noarch]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - noarch
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/noarch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-debuginfo]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch - Debug
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/$basearch/debug
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-source]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch - Source
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/SRPMS
+failovermethod=priority
+enabled=0
+gpgcheck=0

--- a/ISISPostProcessRPM/rpmbuild/SPECS/autoreduce-mq.spec
+++ b/ISISPostProcessRPM/rpmbuild/SPECS/autoreduce-mq.spec
@@ -30,10 +30,13 @@ install -m 664 ../autoreduce-mq/etc/autoreduce/post_process_consumer.conf  %{bui
 install -m 755 -d 	 ../autoreduce-mq/usr	 %{buildroot}/usr
 mkdir -p %{buildroot}%{_bindir}
 install -m 755	 ../autoreduce-mq/usr/bin/autoreduction_logging_setup.py	 %{buildroot}%{_bindir}/autoreduction_logging_setup.py
+install -m 755	 ../autoreduce-mq/usr/bin/daemon.py	 %{buildroot}%{_bindir}/daemon.py
 install -m 755	 ../autoreduce-mq/usr/bin/queueProcessor.py	 %{buildroot}%{_bindir}/queueProcessor.py
 install -m 755	 ../autoreduce-mq/usr/bin/queueProcessor_daemon.py	 %{buildroot}%{_bindir}/queueProcessor_daemon.py
 install -m 755	 ../autoreduce-mq/usr/bin/Configuration.py	 %{buildroot}%{_bindir}/Configuration.py
 install -m 755	 ../autoreduce-mq/usr/bin/PostProcessAdmin.py	 %{buildroot}%{_bindir}/PostProcessAdmin.py
+install -m 755	 ../autoreduce-mq/usr/bin/statusMonitor.py	 %{buildroot}%{_bindir}/statusMonitor.py
+install -m 755	 ../autoreduce-mq/usr/bin/statusMonitor_daemon.py	 %{buildroot}%{_bindir}/statusMonitor_daemon.py
 
 
 %post
@@ -43,6 +46,9 @@ install -m 755	 ../autoreduce-mq/usr/bin/PostProcessAdmin.py	 %{buildroot}%{_bin
 %attr(755, -, -) %{_bindir}/autoreduction_logging_setup.py
 %attr(755, -, -) %{_bindir}/queueProcessor.py
 %attr(755, -, -) %{_bindir}/queueProcessor_daemon.py
+%attr(755, -, -) %{_bindir}/statusMonitor.py
+%attr(755, -, -) %{_bindir}/statusMonitor_daemon.py
 
+%attr(755, -, -) %{_bindir}/daemon.py
 %attr(755, -, -) %{_bindir}/Configuration.py
 %attr(755, -, -) %{_bindir}/PostProcessAdmin.py

--- a/ISISPostProcessRPM/rpmbuild/SPECS/autoreduce-mq.spec
+++ b/ISISPostProcessRPM/rpmbuild/SPECS/autoreduce-mq.spec
@@ -26,7 +26,9 @@ Autoreduce program to automatically catalog and reduce neutron data
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}%{_sysconfdir}/autoreduce
+mkdir -p %{buildroot}/opt/activemq/conf
 install -m 664 ../autoreduce-mq/etc/autoreduce/post_process_consumer.conf  %{buildroot}%{_sysconfdir}/autoreduce/post_process_consumer.conf
+install -m 664 ../autoreduce-mq/opt/activemq/conf/activemq.xml  %{buildroot}/opt/activemq/conf/activemq.xml
 install -m 755 -d 	 ../autoreduce-mq/usr	 %{buildroot}/usr
 mkdir -p %{buildroot}%{_bindir}
 install -m 755	 ../autoreduce-mq/usr/bin/autoreduction_logging_setup.py	 %{buildroot}%{_bindir}/autoreduction_logging_setup.py
@@ -43,6 +45,7 @@ install -m 755	 ../autoreduce-mq/usr/bin/statusMonitor_daemon.py	 %{buildroot}%{
 
 %files
 %config %{_sysconfdir}/autoreduce/post_process_consumer.conf
+%config /opt/activemq/conf/activemq.xml
 %attr(755, -, -) %{_bindir}/autoreduction_logging_setup.py
 %attr(755, -, -) %{_bindir}/queueProcessor.py
 %attr(755, -, -) %{_bindir}/queueProcessor_daemon.py

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/etc/autoreduce/post_process_consumer.conf
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/etc/autoreduce/post_process_consumer.conf
@@ -1,8 +1,8 @@
 {
     "brokers": "localhost:61613",
     "amq_queues": ["/queue/ReductionPending"],
-    "amq_user": "",
-    "amq_pwd": "",
+    "amq_user": "autoreduce",
+    "amq_pwd": "password",
     "postprocess_error": "/queue/ReductionError",
     "reduction_started": "/queue/ReductionStarted",
     "reduction_complete": "/queue/ReductionComplete",

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/opt/activemq/conf/activemq.xml
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/opt/activemq/conf/activemq.xml
@@ -1,0 +1,133 @@
+<!--
+    ActiveMQ config file for ISIS autoreduction.
+-->
+
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+   <!-- Allows accessing the server log -->
+    <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+          lazy-init="false" scope="singleton"
+          init-method="start" destroy-method="stop">
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" schedulerSupport="true">
+
+        <plugins>
+            <simpleAuthenticationPlugin>
+                <users>
+                    <authenticationUser username="autoreduce" password="password" groups="users,admins"/>
+                </users>
+            </simpleAuthenticationPlugin>
+        </plugins>
+
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                    <!-- The constantPendingMessageLimitStrategy is used to prevent
+                         slow topic consumers to block producers and affect other consumers
+                         by limiting the number of messages that are retained
+                         For more information, see:
+
+                         http://activemq.apache.org/slow-consumer-handling.html
+
+                    -->
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+                <policyEntry queue=">" queuePrefetch="1" prioritizedMessages="true" useCache="false" expireMessagesPeriod="0"/>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="true"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before disabling caching and/or slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+          -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="15 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+<!--            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>-->
+            <transportConnector name="stomp+ssl" uri="stomp+ssl://0.0.0.0:61613?transport.enabledProtocols=TLSv1,TLSv1.1,TLSv1.2&amp;maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <sslContext>
+                <sslContext keyStore="broker.ks" keyStorePassword="KEY_STORE_PASSWORD"
+                trustStore="client.ts" trustStorePassword="KEY_STORE_PASSWORD"/>
+        </sslContext>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>

--- a/ISISPostProcessRPM/setup.sh
+++ b/ISISPostProcessRPM/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ~
+basedir=$(pwd)
 read -s -p "Enter a password for the ActiveMQ certificate keystore (at least 6 characters):" storepass
 echo ""
 
@@ -50,7 +50,7 @@ then
     keytool -export -noprompt -alias client -keystore client.ks -file client_cert -storepass $storepass
     keytool -import -noprompt -alias broker -keystore client.ts -file broker_cert -keypass $storepass -storepass $storepass
     keytool -import -noprompt -alias client -keystore broker.ts -file client_cert -keypass $storepass -storepass $storepass
-    cd ~
+    cd $basedir
 fi
 
 
@@ -58,7 +58,7 @@ fi
 if [ ! -e /usr/bin/queueProcessor_daemon.py ]
 then
     echo "Installing autoreduction..."
-    cd ~/autoreduce
+    cd $basedir/autoreduce
     
     # Insert keystore password into ActiveMQ conf
     sed -i "s/KEY_STORE_PASSWORD/$storepass/" ISISPostProcessRPM/rpmbuild/autoreduce-mq/opt/activemq/conf/activemq.xml
@@ -68,9 +68,9 @@ then
     rpm -i SNSPostProcessRPM/rpmbuild/libs/* 
     cd ISISPostProcessRPM/rpmbuild/
     ./make-autoreduce-rpm.sh
-    rpm -i ~/rpmbuild/RPMS/x86_64/autoreduce-mq-*.rpm
+    rpm -i $basedir/rpmbuild/RPMS/x86_64/autoreduce-mq-*.rpm
     
-    cd ~
+    cd $basedir
 fi
 
 # Additional setup

--- a/ISISPostProcessRPM/setup.sh
+++ b/ISISPostProcessRPM/setup.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+cd ~
+
+isInstalled() {
+    yum list installed "$1" >/dev/null 2>&1  || command -v "$1" >/dev/null 2>&1
+}
+
+isis_rhel="[isis-rhel]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-noarch]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - noarch
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/noarch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-debuginfo]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch - Debug
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/$basearch/debug
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[isis-rhel-source]
+name=ISIS Software Repository for Redhat Enterprise Linux $releasever - $basearch - Source
+baseurl=http://yum.isis.rl.ac.uk/rhel/$releasever/SRPMS
+failovermethod=priority
+enabled=0
+gpgcheck=0"
+
+
+# Install Mantid
+if [ ! isInstalled mantid ]
+then
+    echo "Installing mantid..."
+    if [ ! -e /etc/yum.repos.d/isis-rhel.repo ] 
+    then
+        $isis_rhel > /etc/yum.repos.d/isis-rhel.repo
+    fi
+    yum install -y mantid
+fi
+
+
+# Install ActiveMQ
+if [ ! -d /opt/activemq ]
+then
+    echo "Installing ActiveMQ..."
+
+    wget http://archive.apache.org/dist/activemq/5.11.1/apache-activemq-5.11.1-bin.tar.gz
+    tar -zxvf apache-activemq-5.11.1-bin.tar.gz
+    sudo mv apache-activemq-5.11.1 /opt/
+    sudo ln -sf /opt/apache-activemq-5.11.1/ /opt/activemq
+
+    # Configure ActiveMQ
+    if [ -d /opt/activemq/examples ]
+    then
+        rm -rf /opt/activemq/examples
+    fi
+    mv /opt/activemq/conf/activemq.xml /opt/activemq/conf/activemq.xml.old
+    activemq_conf=/opt/activemq/conf/activemq.xml # we will install our config here later
+
+    # Configure ActiveMQ certs
+    cd /opt/activemq/conf
+    read -s -p "Enter a password for the keystore password (at least 6 characters:" storepass
+    echo ""
+    keytool -genkey -noprompt -alias broker -dname "CN=reduce.isis.cclrc.ac.uk" -keyalg RSA -keystore broker.ks -validity 2160 -keypass $storepass -storepass $storepass
+    keytool -genkey -noprompt -alias client -dname "CN=reduce.isis.cclrc.ac.uk" -keyalg RSA -keystore client.ks -validity 2160 -keypass $storepass -storepass $storepass
+    keytool -export -noprompt -alias broker -keystore broker.ks -file broker_cert -storepass $storepass
+    keytool -export -noprompt -alias client -keystore client.ks -file client_cert -storepass $storepass
+    keytool -import -noprompt -alias broker -keystore client.ts -file broker_cert -keypass $storepass -storepass $storepass
+    keytool -import -noprompt -alias client -keystore broker.ts -file client_cert -keypass $storepass -storepass $storepass
+    cd ~
+fi
+
+
+# Install autoreduce
+if [ ! -e /usr/bin/queueProcessor_daemon.py ]
+then
+    # Get the autoreduce repository
+    echo "Installing autoreduction..."
+    cd ~/autoreduce
+
+    # Install RPMs
+    rpm -i SNSPostProcessRPM/rpmbuild/libs/* 
+    cd ISISPostProcessRPM/rpmbuild/
+    ./make-autoreduce-rpm.sh
+    rpm -i ~/rpmbuild/RPMS/x86_64/autoreduce-mq-*.rpm
+    
+    cd ~
+fi
+
+# Additional setup
+if [ -d /autoreducetmp ]
+then
+    mkdir /autoreducetmp
+    chown "ISISautoreduce@fed.cclrc.ac.uk" /autoreducetmp
+fi
+if [ ! isInstalled "python-pip" ]
+then
+    yum install -y "python-pip"
+fi
+pip install stomp.py daemon twisted service_identity
+
+
+echo "Setup complete. ActiveMQ credentials should be changed in '$activemq_conf' and '/etc/autoreduce/post_process_consumer.conf'. ActiveMQ can be started by running '/opt/activemq/bin/activemq start', the queue processor by 'python /usr/bin/queueProcessor_daemon.py start' and the monitor by 'python /usr/bin/statusMonitor_daemon_daemon.py start'."
+
+

--- a/ISISPostProcessRPM/setup.sh
+++ b/ISISPostProcessRPM/setup.sh
@@ -29,7 +29,7 @@ then
 
     rm -rf apache-activemq-5.11.1*
     wget http://archive.apache.org/dist/activemq/5.11.1/apache-activemq-5.11.1-bin.tar.gz
-    tar -zxvf apache-activemq-5.11.1-bin.tar.gz
+    tar -zxf apache-activemq-5.11.1-bin.tar.gz
     sudo mv apache-activemq-5.11.1 /opt/
     sudo ln -sf /opt/apache-activemq-5.11.1/ /opt/activemq
 
@@ -57,9 +57,11 @@ fi
 # Install autoreduce
 if [ ! -e /usr/bin/queueProcessor_daemon.py ]
 then
-    # Get the autoreduce repository
     echo "Installing autoreduction..."
     cd ~/autoreduce
+    
+    # Insert keystore password into ActiveMQ conf
+    sed -i "s/KEY_STORE_PASSWORD/$storepass/" ISISPostProcessRPM/rpmbuild/autoreduce-mq/opt/activemq/conf/activemq.xml
 
     # Install RPMs
     yum install -y "rpm-build"
@@ -77,8 +79,8 @@ then
     mkdir /autoreducetmp
     chown "ISISautoreduce@fed.cclrc.ac.uk" /autoreducetmp
 fi
-yum install -y "python-pip" "python-dev"
-pip install stomp.py daemon twisted service_identity
+yum install -y "python-pip" "python-devel"
+pip install stomp.py twisted service_identity
 
 
 echo "Setup complete. ActiveMQ credentials should be changed in '$activemq_conf' and '/etc/autoreduce/post_process_consumer.conf'. ActiveMQ can be started by running '/opt/activemq/bin/activemq start', the queue processor by 'python /usr/bin/queueProcessor_daemon.py start' and the monitor by 'python /usr/bin/statusMonitor_daemon.py start'."

--- a/ISISPostProcessRPM/setup.sh
+++ b/ISISPostProcessRPM/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 cd ~
+read -s -p "Enter a password for the ActiveMQ certificate keystore (at least 6 characters):" storepass
+echo ""
 
 isInstalled() {
     echo "Checking installed packages."
@@ -25,6 +27,7 @@ if [ ! -d /opt/activemq ]
 then
     echo "Installing ActiveMQ..."
 
+    rm -rf apache-activemq-5.11.1*
     wget http://archive.apache.org/dist/activemq/5.11.1/apache-activemq-5.11.1-bin.tar.gz
     tar -zxvf apache-activemq-5.11.1-bin.tar.gz
     sudo mv apache-activemq-5.11.1 /opt/
@@ -40,8 +43,6 @@ then
 
     # Configure ActiveMQ certs
     cd /opt/activemq/conf
-    read -s -p "Enter a password for the keystore password (at least 6 characters:" storepass
-    echo ""
     rm -f {client,broker}.{ks,ts}
     keytool -genkey -noprompt -alias broker -dname "CN=reduce.isis.cclrc.ac.uk" -keyalg RSA -keystore broker.ks -validity 2160 -keypass $storepass -storepass $storepass
     keytool -genkey -noprompt -alias client -dname "CN=reduce.isis.cclrc.ac.uk" -keyalg RSA -keystore client.ks -validity 2160 -keypass $storepass -storepass $storepass


### PR DESCRIPTION
Addresses https://github.com/mantidproject/autoreduce/issues/268

This adds a script `setup.sh` and a few config files to make installing the backend much easier. I've tested this in CentOS 7 on a clean VM.

For the frontend this is less relevant, since much of the installation on Windows Server is quite interactive;  the solution wouldn't be as simple as this.