### PR TITLE
ICAT Cache

### DIFF
--- a/WebApp/ISIS/Documentation/Technical Documentation.md
+++ b/WebApp/ISIS/Documentation/Technical Documentation.md
@@ -138,6 +138,12 @@ ICATCommunication(URL='',AUTH='',SESSION={},USER='',PASSWORD='')
 
 ICATCommunication will logout of ICAT when it goes out of the scope of the `with` statement.
 
+#### icat_cache.py
+
+This wraps ICATCommunication, implementing a cache mechanism that stores query results. It's intended to be used exactly as ICATCommunication would be (i.e., in a `with` statement).
+
+The setting `CACHE_LIFETIME` (in seconds) controls how long objects live in the cache. If ICATCache finds a cache object that's younger than this setting in the database, it will use that instead of going to ICATCommunication. Otherwise, it will try to connect to ICAT via ICATCommunication and make the query, storing it to the cache. If this fails somehow, it'll return the stale cache object if there is one, or else return `None`.
+
 #### uows_client.py
 
 This handles communication with the User Office Web Service to handle authentication and retrieving user details.
@@ -168,6 +174,8 @@ Provides application-wide utilities. Contains `SeparatedValuesField` that can be
 #### view_utils.py
 
 Provides application-wide function decorators for view methods. These include things like checking a session ID is still valid (`login_and_uows_valid`) or that a user is a staff memeber (`require_staff`). `require_staff` and `require_admin` will both throw a [403 Forbidden](http://en.wikipedia.org/wiki/HTTP_403) is the current user doesn't have the appropriate permissions. If not logged in, the user will be redirected to the login page first.
+
+`check_permissions` is used for general-purpose permissions checking; it looks at the keyword arguments of the function, and checks that the user has access to the run/instrument/experiment that's being looked at, checking ICATCache for the permissions.
 
 The main function worth taking note of is `render_with`. This is used by all view functions except those that are called from within another view (as these don't trigger function decorators). When used, this expect the function to return a dictionary (the context dictionary that will be used by the template) which it then adds any active notifications, flags and values such as support email and then calling the `render_to_response` on the appropriate template file with the dictionary fully populated. This means there is a single location to put all context variables that are needed on all (or most) pages without having to add it to each view function.
 

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/admin.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from models import *
+
+admin.site.register(UserCache)
+admin.site.register(InstrumentCache)
+admin.site.register(ExperimentCache)

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
@@ -1,10 +1,9 @@
 import datetime, logging
 logger = logging.getLogger("app")
 from django.utils import timezone
+from autoreduce_webapp.settings import CACHE_LIFETIME
 from autoreduce_webapp.icat_communication import ICATCommunication
 from autoreduce_webapp.models import UserCache, InstrumentCache, ExperimentCache
-
-CACHE_LIFETIME = 3600
 
 
 class ICATConnectionException(Exception):

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
@@ -1,0 +1,87 @@
+import datetime
+from django.utils import timezone
+from autoreduce_webapp.icat_communication import ICATCommunication
+from autoreduce_webapp.models import UserCache, InstrumentCache, ExperimentCache
+
+CACHE_LIFETIME = 3600
+
+
+class ICATCache(object):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.icat = None
+    
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.icat is not None:
+            self.icat.__exit__()
+            
+    def open_icat(self):
+        if self.icat is None:
+            self.icat = ICATCommunication(**self.kwargs)
+            
+    def is_valid(self, cache_obj):
+        return cache_obj.created + datetime.timedelta(seconds=CACHE_LIFETIME) > timezone.now()
+        
+    def to_list(self, l):
+        return ",".join(map(str, l))
+            
+    def cull_invalid(self, list):
+        rlist = []
+        for obj in list:
+            obj.delete() if not self.is_valid(obj) else rlist.append(obj)
+        return rlist
+        
+    def update_cache(self, obj_type, obj_id):
+        self.open_icat()
+        
+        new_obj = obj_type(**{attr:(getattr(self.icat, func)(obj_id) if typ is None else self.to_list(getattr(self.icat, func)(obj_id))) for (func, model, attr, typ) in func_list if model == obj_type})
+        new_obj.id_name = obj_id
+        new_obj.save()
+        return new_obj
+        
+        
+    def get_valid_experiments_for_instruments(self, user_number, instruments):
+        return {instrument: self.get_valid_experiments_for_instrument(instrument) for instrument in instruments}
+    
+            
+
+func_list = [ ("get_owned_instruments", UserCache, "owned_instruments", str)
+            , ("get_valid_instruments", UserCache, "valid_instruments", str)
+            , ("is_admin", UserCache, "is_admin", None)
+            , ("is_instrument_scientist", UserCache, "is_instrument_scientist", None)
+            , ("get_associated_experiments", UserCache, "associated_experiments", int)
+            
+            , ("get_upcoming_experiments_for_instrument", InstrumentCache, "upcoming_experiments", int)
+            , ("get_valid_experiments_for_instrument", InstrumentCache, "valid_experiments", int)
+            
+            , ("get_experiment_details", ExperimentCache, "__dict__", None)
+            ]
+            
+for (member_name, obj_type, cache_attr, list_type) in func_list:
+    def member_func(self, object_id):
+        # Remove expired objects, then check if the relevant object is in the cache, putting it in if it isn't.
+        in_cache = self.cull_invalid(obj_type.objects.filter(id_name = object_id).order_by("-created"))
+        new_obj = in_cache[0] if in_cache else self.update_cache(obj_type, object_id)
+        
+        # Get the attribute we want, parsing it as a list if we should.
+        attr = getattr(new_obj, cache_attr)
+        if list_type is not None:
+            attr = map(list_type, attr.split(","))
+        
+        return attr
+        
+    setattr(ICATCache, member_name, member_func)
+            
+# get_owned_instruments(int(request.user.username))
+# get_valid_instruments(int(request.user.username))
+# get_associated_experiments(int(request.user.username))
+# get_upcoming_experiments_for_instrument
+# is_admin(int(person['usernumber']))
+# is_instrument_scientist(int(person['usernumber']))
+# get_experiment_details(int(reference_number))
+
+
+### get_valid_experiments_for_instruments(int(request.user.username), instrument_names))

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
@@ -26,7 +26,7 @@ class ICATCache(object):
 
     def __exit__(self, type, value, traceback):
         if self.icat is not None:
-            self.icat.__exit__()
+            self.icat.__exit__(type, value, traceback)
             
     def open_icat(self):
         """ Try to open an ICAT session, if we don't have one already. """

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
@@ -60,7 +60,7 @@ func_list = [ ("get_owned_instruments", UserCache, "owned_instruments", str)
             , ("get_experiment_details", ExperimentCache, "__dict__", None)
             ]
             
-for (member_name, obj_type, cache_attr, list_type) in func_list:
+def make_member_func(member_name, obj_type, cache_attr, list_type):
     def member_func(self, object_id):
         # Remove expired objects, then check if the relevant object is in the cache, putting it in if it isn't.
         in_cache = self.cull_invalid(obj_type.objects.filter(id_name = object_id).order_by("-created"))
@@ -74,6 +74,10 @@ for (member_name, obj_type, cache_attr, list_type) in func_list:
         return attr
         
     setattr(ICATCache, member_name, member_func)
+    
+for t in func_list:
+    make_member_func(*t)
+        
             
 # get_owned_instruments(int(request.user.username))
 # get_valid_instruments(int(request.user.username))

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_cache.py
@@ -114,7 +114,7 @@ def make_member_func(obj_type, cache_attr, list_type):
         # Get the attribute we want, parsing it as a list if we should.
         attr = getattr(new_obj, cache_attr)
         if list_type is not None:
-            attr = map(list_type, attr.split(","))
+            attr = map(list_type, filter(bool, attr.split(",")))
         
         return attr
     return member_func

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
@@ -161,6 +161,23 @@ class ICATCommunication(object):
 
         return instruments_dict
 
+    '''
+        Returns all experiments allowed for a given instrument
+    '''
+    def get_valid_experiments_for_instrument(self, instrument):
+        logger.debug("Calling ICATCommunication.get_valid_experiments_for_instrument")
+        from reduction_viewer.models import Setting
+
+        try:
+            number_of_years = int(Setting.objects.get(name='ICAT_YEARS_TO_SHOW').value)
+        except:
+            number_of_years = 3
+        years_back = datetime.datetime.now() - datetime.timedelta(days=(number_of_years*365.24))
+
+        experiments = Set()
+        self._add_list_to_set(self.client.search("SELECT i.name FROM Investigation i JOIN i.investigationInstruments inst WHERE i.name NOT LIKE 'CAL%' and i.endDate > '"+str(years_back)+"' and (inst.instrument.name = '"+instrument+"' OR inst.instrument.fullName = '"+instrument+"')"), experiments)
+        return sorted(experiments, reverse=True)
+
     def get_upcoming_experiments_for_instrument(self, instrument):
         logger.debug("Calling ICATCommunication.get_upcoming_experiments_for_instrument")
         if not instrument:

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
@@ -44,8 +44,9 @@ class ICATCommunication(object):
             raise TypeError("Reference number must be a number")
 
         if reference_number > 0:
-            investigation = self.client.search("SELECT i from Investigation i where i.name = '" + str(reference_number) + "' INCLUDE i.investigationInstruments.instrument, i.investigationUsers.user")
-            if investigation and investigation[0]:
+            try:
+                investigation = self.client.search("SELECT i from Investigation i where i.name = '" + str(reference_number) + "' INCLUDE i.investigationInstruments.instrument, i.investigationUsers.user")
+                
                 trimmed_investigation = {
                     'reference_number' : investigation[0].name,
                     'start_date' : investigation[0].startDate,
@@ -59,6 +60,9 @@ class ICATCommunication(object):
                     if investigationUser.role == 'principal_experimenter':
                         trimmed_investigation['pi'] = investigationUser.user.fullName
                 return trimmed_investigation
+                
+            except:
+                pass
                 
         trimmed_investigation = {
             'reference_number' : str(reference_number),

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/icat_communication.py
@@ -59,18 +59,17 @@ class ICATCommunication(object):
                     if investigationUser.role == 'principal_experimenter':
                         trimmed_investigation['pi'] = investigationUser.user.fullName
                 return trimmed_investigation
-        else:
-            trimmed_investigation = {
-                'reference_number' : str(reference_number),
-                'start_date' : 'N/A',
-                'end_date' : 'N/A',
-                'title' : 'N/A',
-                'summary' : u'N/A',
-                'pi' : ''
-                }
+                
+        trimmed_investigation = {
+            'reference_number' : str(reference_number),
+            'start_date' : 'N/A',
+            'end_date' : 'N/A',
+            'title' : 'N/A',
+            'summary' : u'N/A',
+            'pi' : ''
+            }
 
-            return trimmed_investigation
-        return None
+        return trimmed_investigation
 
     '''
         Returns a set of all instruments a given user can see.

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
@@ -1,30 +1,29 @@
 from django.db import models
-from reduction_viewer.models import Instrument, Experiment, ReductionRun
 
 
-class Cache(model.Model):
+class Cache(models.Model):
     created = models.DateTimeField(auto_now_add=True, blank=False)
 
     def __unicode__(self):
-        return u'%s' % self.name
+        return u'%s' % self.id_name
     
 
 class UserCache(Cache):
-    name = models.IntegerField(blank=False)
-    associated_experiments = models.ManyToManyField(Experiment)
-    owned_instruments = models.ManyToManyField(Instrument)
-    valid_instruments = models.ManyToManyField(Instrument)
+    id_name = models.IntegerField(blank=False)
+    associated_experiments = models.TextField(blank=True)
+    owned_instruments = models.TextField(blank=True)
+    valid_instruments = models.TextField(blank=True)
     is_admin = models.BooleanField(default=False)
     is_instrument_scientist = models.BooleanField(default=False)
 
 
 class InstrumentCache(Cache):
-    name = models.CharField(max_length=80)
-    upcoming_experiments = models.ManyToManyField(Experiment)
+    id_name = models.CharField(max_length=80)
+    upcoming_experiments = models.TextField(blank=True)
 
 
 class ExperimentCache(Cache):
-    reference_number = models.IntegerField(blank=False)
+    id_name = models.IntegerField(blank=False)
     start_date = models.TextField(default='')
     end_date = models.TextField(default='')
     title = models.TextField(default='')

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
@@ -1,0 +1,33 @@
+from django.db import models
+from reduction_viewer.models import Instrument, Experiment, ReductionRun
+
+
+class Cache(model.Model):
+    created = models.DateTimeField(auto_now_add=True, blank=False)
+
+    def __unicode__(self):
+        return u'%s' % self.name
+    
+
+class UserCache(Cache):
+    name = models.IntegerField(blank=False)
+    associated_experiments = models.ManyToManyField(Experiment)
+    owned_instruments = models.ManyToManyField(Instrument)
+    valid_instruments = models.ManyToManyField(Instrument)
+    is_admin = models.BooleanField(default=False)
+    is_instrument_scientist = models.BooleanField(default=False)
+
+
+class InstrumentCache(Cache):
+    name = models.CharField(max_length=80)
+    upcoming_experiments = models.ManyToManyField(Experiment)
+
+
+class ExperimentCache(Cache):
+    reference_number = models.IntegerField(blank=False)
+    start_date = models.TextField(default='')
+    end_date = models.TextField(default='')
+    title = models.TextField(default='')
+    summary = models.TextField(default='')
+    instrument = models.TextField(default='')
+    pi = models.TextField(default='')

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/models.py
@@ -20,6 +20,7 @@ class UserCache(Cache):
 class InstrumentCache(Cache):
     id_name = models.CharField(max_length=80)
     upcoming_experiments = models.TextField(blank=True)
+    valid_experiments = models.TextField(blank=True)
 
 
 class ExperimentCache(Cache):

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py
@@ -183,6 +183,7 @@ UOWS_LOGIN_URL = 'https://users.facilities.rl.ac.uk/auth/?service=http://reduce.
 
 
 # Email for notifications
+
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'exchsmtp.stfc.ac.uk'
 EMAIL_PORT = 25
@@ -190,8 +191,10 @@ EMAIL_ERROR_RECIPIENTS = ['isisreduce@stfc.ac.uk']
 EMAIL_ERROR_SENDER = 'autoreduce@reduce.isis.cclrc.ac.uk'
 BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 
+
 # Constant vars
 
 FACILITY = "ISIS"
 PRELOAD_RUNS_UNDER = 100 # If the index run list has fewer than this many runs to show the user, preload them all.
+CACHE_LIFETIME = 3600 # Objects in ICATCache live this many seconds when ICAT is available to update them.
 USER_ACCESS_CHECKS = True # Should the webapp prevent users from accessing runs/instruments they're not allowed to?

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -6,7 +6,7 @@ logger = logging.getLogger('django')
 from reduction_variables.models import InstrumentVariable, RunVariable
 from reduction_viewer.models import ReductionRun, Notification
 from reduction_viewer.utils import InstrumentUtils, StatusUtils, ReductionRunUtils
-from autoreduce_webapp.icat_communication import ICATCommunication
+from autoreduce_webapp.icat_cache import ICATCache
 
 class DataTooLong(ValueError):
     pass
@@ -204,7 +204,7 @@ class InstrumentVariablesUtils(object):
         
         # Get the upcoming experiments, and then select all variables for these experiments.
         upcoming_experiments = []
-        with ICATCommunication() as icat:
+        with ICATCache() as icat:
             upcoming_experiments = list(icat.get_upcoming_experiments_for_instrument(instrument_name))
         upcoming_variables_by_experiment = InstrumentVariable.objects.filter(instrument = instrument, experiment_reference__in = upcoming_experiments).order_by('experiment_reference')
                 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -2,10 +2,8 @@ from django.shortcuts import redirect
 from django.core.context_processors import csrf
 from django.template import RequestContext
 from django.shortcuts import render_to_response
-from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseForbidden
-from autoreduce_webapp.settings import USER_ACCESS_CHECKS
-from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, has_valid_login, handle_redirect
+from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, has_valid_login, handle_redirect, check_permissions
 from reduction_variables.models import InstrumentVariable, RunVariable
 from reduction_variables.utils import InstrumentVariablesUtils, MessagingUtils
 from reduction_viewer.models import Instrument, ReductionRun
@@ -88,12 +86,10 @@ def instrument_summary(request, instrument):
     return render_to_response('snippets/instrument_summary_variables.html', context_dictionary, RequestContext(request))
 
 @login_and_uows_valid
-def delete_instrument_variables(request, instrument, start=0, end=0, experiment_reference=None):
+@check_permissions
+def delete_instrument_variables(request, instrument=None, start=0, end=0, experiment_reference=None):
     instrument_name = instrument
     start, end = int(start), int(end)
-    # Check the user has permission
-    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument_name not in request.session['owned_instruments']:
-        raise PermissionDenied()
     
     # We "save" an empty list to delete the previous variables.
     if experiment_reference is not None:
@@ -104,12 +100,9 @@ def delete_instrument_variables(request, instrument, start=0, end=0, experiment_
     return redirect('instrument_summary', instrument=instrument_name)
 
 @login_and_uows_valid
+@check_permissions
 @render_with('instrument_variables.html')
-def instrument_variables(request, instrument, start=0, end=0, experiment_reference=0):
-    # Check that the user has permission.
-    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
-        
+def instrument_variables(request, instrument=None, start=0, end=0, experiment_reference=0):        
     instrument_name = instrument
     start, end = int(start), int(end)
     
@@ -221,12 +214,9 @@ def instrument_variables(request, instrument, start=0, end=0, experiment_referen
 
 
 @login_and_uows_valid
+@check_permissions
 @render_with('submit_runs.html')
-def submit_runs(request, instrument):
-    # Check the user has permission
-    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
-
+def submit_runs(request, instrument=None):
     instrument = Instrument.objects.get(name=instrument)
 
     if request.method == 'GET':
@@ -264,11 +254,10 @@ def submit_runs(request, instrument):
 
         return context_dictionary
 
-
-#@require_staff
 @login_and_uows_valid
+@check_permissions
 @render_with('snippets/edit_variables.html')
-def current_default_variables(request, instrument):
+def current_default_variables(request, instrument=None):
     variables = InstrumentVariablesUtils().get_default_variables(instrument)
     standard_vars = {}
     advanced_vars = {}
@@ -323,10 +312,10 @@ def run_summary(request, run_number, run_version=0):
     context_dictionary.update(csrf(request))
     return render_to_response('snippets/run_variables.html', context_dictionary, RequestContext(request))
 
-#@require_staff
 @login_and_uows_valid
+@check_permissions
 @render_with('run_confirmation.html')
-def run_confirmation(request, instrument):
+def run_confirmation(request, instrument=None):
     if request.method != 'POST':
         return redirect('instrument_summary', instrument=instrument.name)
         
@@ -363,16 +352,6 @@ def run_confirmation(request, instrument):
     rb_number = ReductionRun.objects.filter(instrument=instrument, run_number__in=run_numbers).values_list('experiment__reference_number', flat=True).distinct()
     if len(rb_number) > 1:
         context_dictionary['error'] = 'Runs span multiple experiment numbers (' + ','.join(str(i) for i in rb_number) + ') please select a different range.'
-
-    # Check that RB numbers are allowed
-    if not request.user.is_superuser:
-        experiments_allowed = request.session['experiments_to_show'].get(instrument.name)
-        if (experiments_allowed is not None) and (str(rb_number[0]) not in experiments_allowed):
-            context_dictionary['error'] = "Permission denied. You do not have permission to request re-runs on the associated experiment number."
-
-    # Quit on error.
-    if 'error' in context_dictionary:
-        return context_dictionary
             
     for run_number in run_numbers:
         old_reduction_run = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version').first()
@@ -431,8 +410,8 @@ def run_confirmation(request, instrument):
             
     return context_dictionary
 
-    
-def preview_script(request, instrument, run_number=0, experiment_reference=0):
+@check_permissions
+def preview_script(request, instrument=None, run_number=0, experiment_reference=0):
     # Can't use login decorator as need to return AJAX error message if fails
     if not has_valid_login(request):
         redirect_response = handle_redirect(request)
@@ -441,12 +420,6 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         else:
             error = {'redirect_url': redirect_response.url}
             return HttpResponseForbidden(json.dumps(error))
-            
-    # Check permissions
-    if not request.user.is_superuser\
-            and   ((experiment_reference and experiment_reference not in request.session['experiments'])\
-                or (instrument           and instrument           not in request.session['owned_instruments'])):
-        raise PermissionDenied()
 
     if request.method == 'GET':
         reduction_run = ReductionRun.objects.filter(run_number=run_number)

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/models.py
@@ -16,9 +16,6 @@ class Experiment(models.Model):
     def __unicode__(self):
         return u'%s' % self.reference_number
 
-    def get_ICAT_details(self):
-        return autoreduce_webapp.icat_communication.get_experiment_details(self.reference_number)
-
 class Status(models.Model):
     value = models.CharField(max_length=25)
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_viewer/views.py
@@ -11,7 +11,7 @@ from reduction_viewer.models import Experiment, ReductionRun, Instrument
 from reduction_viewer.utils import StatusUtils, ReductionRunUtils
 from reduction_viewer.view_utils import deactivate_invalid_instruments
 from reduction_variables.utils import MessagingUtils
-from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_admin
+from autoreduce_webapp.view_utils import login_and_uows_valid, render_with, require_admin, check_permissions
 import operator
 import json
 import logging
@@ -41,10 +41,6 @@ def index(request):
                     return_url = use_query_next
                 else:
                     return_url = default_next
-                # Cache these for the session as they are used for permission checking
-                with ICATCache(AUTH='uows', SESSION={'sessionid':request.session['sessionid']}) as icat:
-                    request.session['owned_instruments'] = icat.get_owned_instruments(int(request.user.username))
-                    request.session['experiments'] = icat.get_associated_experiments(int(request.user.username))
 
     return redirect(return_url)
 
@@ -57,7 +53,6 @@ def logout(request):
     request.session.flush()
     return redirect('index')
 
-#@require_staff
 @login_and_uows_valid
 @render_with('run_queue.html')
 def run_queue(request):
@@ -68,8 +63,9 @@ def run_queue(request):
     
     # Filter those which the user shouldn't be able to see
     if USER_ACCESS_CHECKS and not request.user.is_superuser:
-        pending_jobs = filter(lambda job: job.experiment.reference_number in request.session['experiments'], pending_jobs) # check RB numbers
-        pending_jobs = filter(lambda job: job.instrument.name in request.session['owned_instruments'], pending_jobs) # check instrument
+        with ICATCache(AUTH='uows', SESSION={'sessionid':request.session['sessionid']}) as icat:
+            pending_jobs = filter(lambda job: job.experiment.reference_number in icat.get_associated_experiments(int(request.user.username)), pending_jobs) # check RB numbers
+            pending_jobs = filter(lambda job: job.instrument.name in icat.get_owned_instruments(int(request.user.username)), pending_jobs) # check instrument
     
     context_dictionary = { 'queue' : pending_jobs }
     return context_dictionary
@@ -159,13 +155,11 @@ def run_list(request):
                 instrument_experiments = Experiment.objects.filter(reduction_runs__instrument=instrument).values_list('reference_number', flat=True)
                 for experiment in instrument_experiments:
                     experiments[instrument_name].append(str(experiment))
-            request.session['experiments_to_show'] = experiments
     else:
         with ICATCache(AUTH='uows',SESSION={'sessionid':request.session.get('sessionid')}) as icat:
             instrument_names = icat.get_valid_instruments(int(request.user.username))
             if instrument_names:
                 experiments = request.session.get('experiments_to_show', icat.get_valid_experiments_for_instruments(int(request.user.username), instrument_names))
-                request.session['experiments_to_show'] = experiments
 
     # get database status labels up front to reduce queries to database
     status_error = StatusUtils().get_error()
@@ -251,14 +245,9 @@ def run_list(request):
 
     
 @login_and_uows_valid
+@check_permissions
 @render_with('load_runs.html')
 def load_runs(request, reference_number=None, instrument_name=None):
-    # Check permissions
-    if USER_ACCESS_CHECKS and not request.user.is_superuser\
-            and   ((reference_number and reference_number not in request.session['experiments'])\
-                or (instrument_name  and instrument_name  not in request.session['owned_instruments'])):
-        raise PermissionDenied()
-
     runs = []
     
     if reference_number:
@@ -278,14 +267,11 @@ def load_runs(request, reference_number=None, instrument_name=None):
 
     
 @login_and_uows_valid
+@check_permissions
 @render_with('run_summary.html')
-def run_summary(request, run_number, run_version=0):
+def run_summary(request, run_number=None, run_version=0):
     try:
         run = ReductionRun.objects.get(run_number=run_number, run_version=run_version)
-        # Check the user has permission
-        if USER_ACCESS_CHECKS and not request.user.is_superuser and str(run.experiment.reference_number) not in request.session['experiments']\
-                and str(run.instrument) not in request.session['owned_instruments']:
-            raise PermissionDenied()
         history = ReductionRun.objects.filter(run_number=run_number).order_by('-run_version')
         context_dictionary = { 'run' : run, 'history' : history }
     except PermissionDenied:
@@ -296,14 +282,10 @@ def run_summary(request, run_number, run_version=0):
         
     return context_dictionary
 
-#@require_staff
 @login_and_uows_valid
+@check_permissions
 @render_with('instrument_summary.html')
-def instrument_summary(request, instrument):
-    # Check the user has permission
-    if USER_ACCESS_CHECKS and not request.user.is_superuser and instrument not in request.session['owned_instruments']:
-        raise PermissionDenied()
-
+def instrument_summary(request, instrument=None):
     processing_status = StatusUtils().get_processing()
     queued_status = StatusUtils().get_queued()
     skipped_status = StatusUtils().get_skipped()
@@ -324,12 +306,9 @@ def instrument_summary(request, instrument):
     return context_dictionary
 
 @login_and_uows_valid
+@check_permissions
 @render_with('experiment_summary.html')
-def experiment_summary(request, reference_number):
-    # Check the user's permissions
-    if USER_ACCESS_CHECKS and not request.user.is_superuser and str(reference_number) not in request.session['experiments']:
-       raise PermissionDenied()
-
+def experiment_summary(request, reference_number=None):
     try:
         experiment = Experiment.objects.get(reference_number=reference_number)
         runs = ReductionRun.objects.filter(experiment=experiment).order_by('-run_version')
@@ -374,7 +353,8 @@ def help(request):
     return {}
 
 @login_and_uows_valid
-def instrument_pause(request, instrument):
+@check_permissions
+def instrument_pause(request, instrument=None):
     #TODO: Check ICAT credentials
     instrument_obj = Instrument.objects.get(name=instrument)
     currently_paused = (request.POST.get("currently_paused").lower() == u"false")


### PR DESCRIPTION
Fixes #20, addresses #128 somewhat.

The class `ICATCache` mimics the behaviour of `ICATCommunication`, but keeps a local cache which it will check before using ICATCommunication to send any queries to ICAT. The cache lifetime is `CACHE_LIFETIME` in the settings, currently set to one hour.

In the event that ICAT can't be connected to, it will serve stale cache objects if it has them. This means that if an object has been queried for before, subsequent queries from the frontend will succeed when ICAT is unavailable.

To test:
* Check that all permissions, run/instrument/experiment information, etc., are as they should be on the frontend.
* Temporarily change the cache lifetime to something short and check that the cache is refreshed when it should be (cache objects have a `created` field).
* Temporarily break ICAT access somehow and check that the webapp continues working for objects that have been queried before.