### PR TITLE
Preventing EndOfRunMonitor stopping in the case of file errors

### DIFF
--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -127,10 +127,11 @@ def main():
         event_handler = InstrumentMonitor(inst['name'], inst['use_nexus'], activemq_client, message_lock)
         # This will watch the folder the program is in, it will pick up all changes made in the folder.
         path = event_handler.get_watched_folder()
-        # Start watching files.
-        observer.start()
         # Tell the observer what to watch and give it the class that will handle the events.
         observer.schedule(event_handler, path)
+        
+    # Start watching files.
+    observer.start()
 
 def stop():
     # This function disables the observer, it stop watching the files.

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -50,11 +50,13 @@ class InstrumentMonitor(FileSystemEventHandler):
             self.instrumentFolder = INST_FOLDER % self.instrumentName
         self.instrumentSummaryLoc = self.instrumentFolder + SUMMARY_LOC
         self.instrumentLastRunLoc = self.instrumentFolder + LAST_RUN_LOC
-        self.instrumentDataFolderLoc = self.instrumentFolder + DATA_LOC % self._get_most_recent_cycle()
         with open(self.instrumentLastRunLoc) as lr:
             data = get_data_and_check(lr)
             self.last_run = data[1]
         self.lock = lock
+        
+    def _get_instrument_data_folder_loc(self):
+        return self.instrumentFolder + DATA_LOC % self._get_most_recent_cycle()
 
     def _get_most_recent_cycle(self):
         folders = os.listdir(self.instrumentFolder + '\logs\\')
@@ -69,7 +71,7 @@ class InstrumentMonitor(FileSystemEventHandler):
         and last line of the summary text file to build the query
         """
         filename = ''.join(last_run_data[0:2])  # so MER111 etc
-        run_data_loc = self.instrumentDataFolderLoc + filename + get_file_extension(self.use_nexus)
+        run_data_loc = self._get_instrument_data_folder_loc() + filename + get_file_extension(self.use_nexus)
         return {
             "rb_number": self._get_RB_num(),
             "instrument": self.instrumentName,

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -103,8 +103,7 @@ class InstrumentMonitor(FileSystemEventHandler):
                     self.send_message(data)
         except Exception as e:
             # if this code can't be executed it will raise a logging error towards the user.
-            logging.exception("Error on loading file: ")
-            raise e
+            logging.exception("Error on loading file: ", exc_info=True)
 
     def send_message(self, last_run_data):
         # Puts message together and sends it, along with logging.

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -5,11 +5,11 @@ from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
 # Config settings for cycle number, and instrument file arrangement
-INST_FOLDER = "\\\\isis\inst$\NDX%s\Instrument"
-DATA_LOC = "\data\cycle_%s\\"
-SUMMARY_LOC = "\logs\journal\SUMMARY.txt"
-LAST_RUN_LOC = "\logs\lastrun.txt"
-LOG_FILE = "xx\\monitor_log.txt"
+INST_FOLDER = r"\\isis\inst$\NDX%s\Instrument"
+DATA_LOC = r"\data\cycle_%s\\"
+SUMMARY_LOC = r"\logs\journal\SUMMARY.txt"
+LAST_RUN_LOC = r"\logs\lastrun.txt"
+LOG_FILE = r"xx\monitor_log.txt"
 INSTRUMENTS = [{'name': 'LET', 'use_nexus': True},
                {'name': 'MERLIN', 'use_nexus': False},
                {'name': 'MAPS', 'use_nexus': True},

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -127,10 +127,10 @@ def main():
         event_handler = InstrumentMonitor(inst['name'], inst['use_nexus'], activemq_client, message_lock)
         # This will watch the folder the program is in, it will pick up all changes made in the folder.
         path = event_handler.get_watched_folder()
-        # Tell the observer what to watch and give it the class that will handle the events.
-        observer.schedule(event_handler, path)
         # Start watching files.
         observer.start()
+        # Tell the observer what to watch and give it the class that will handle the events.
+        observer.schedule(event_handler, path)
 
 def stop():
     # This function disables the observer, it stop watching the files.


### PR DESCRIPTION
Fixes #256

Rather than monitoring the monitor thread to restart it on failure, it's clear that the desired behaviour is to just not crash the thread if the file read doesn't succeed. This way, the `on_modified` method will be called again the next time the data file is modified, and if (e.g.) the data format is now correct, the monitor will send a message to `DataReady` as if nothing had happened.

The production server wasn't running the new run monitor until now; this has been fixed. It now uses the script in the main autoreduce folder. This brought out some other issues, which were fixed as below.