### PR TITLE
Script preview

### DIFF
--- a/WebApp/ISIS/Documentation/Technical Documentation.md
+++ b/WebApp/ISIS/Documentation/Technical Documentation.md
@@ -439,33 +439,10 @@ The first is by run number. Any instrument variables with a start run larger tha
 
 The second is by experiment reference number. This checks with ICAT for any experiments on that instrument where the end date is in the future. These are then used to return all instrument variables with a matching reference number. It is possible that this may not return all that is expected as the experiments may not have been loaded into ICAT yet.
 
-### Script Preview Regex
+### Script Preview
 
-```python
-standard_pattern = "(?P<before>(\s)standard_vars\s*=\s*\{(([\s\S])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,\n)[\S\s])+)"
-advanced_pattern = "(?P<before>(\s)advanced_vars\s*=\s*\{(([\s\S])+)['|\"]%s['|\"]\s*:\s*)(?P<value>((?!,\n)[\S\s])+)"
-```
+The reduction script and variables are combined in a preview to make a single, runnable script, in `preview_script()` in `reduction_variables/utils.py`. To do this, any imports of `reduce_vars` is removed, and a class declaration with the imported name substituted. This class declaration contains declarations of `standard_vars` and `advanced_vars`, generated from the relevant reduction variables. The result is reasonably robust to arbitrary changes in the script, since the semantics of import statements are fairly limited, and the variable definitions are fabricated entirely, rather than run as substitutions on existing code.
 
-This regular expression is used to match and replace variables within the `standard_vars` and `advanced_vars` dictionaries. Breaking it down:
-
-`(?P<before>...)` - This is a named capture group used by the regex replace.
-`\s` - This matches any whitespace character. `\s*` optional matches multiple whitespace characters (0-many).
-`\{` and `\}` matches the characters `{` and `}` literally.
-`['|\"]` matches either `'` or `"`.
-`%s` is replaced by the varaible name to be matched against.
-`(?!,\n)` makes sure it DOES NOT match `,` or a newline.
-`[\S\s]` matches any whitespace or non-whitespace character.
-
-Example usage:
-
-```python
-pattern = standard_pattern % name   # Replace '%s' in the regex with the value in 'name'
-value = "test_var"                  #
-value = '\g<before>%s' % value      # Make sure everything before the replaced value is kept. '\g<Before>' inserts everything that matches the '(?P<before>)' capture group
-re.sub(pattern, value, script_file) # Replace the matched pattern in 'script_file' with value
-```
-
-For a live example see: http://regex101.com/r/oJ7iY5/2
 
 ### Base64 Images
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -97,9 +97,9 @@ class VariableUtils(object):
             var_list = str(value).split(',')
             list_text = []
             for list_val in var_list:
-                if list_val:
-                    if list_val and list_val.strip():
-                        list_text.append(str(list_val.strip()))
+                item = list_val.strip().strip("'")
+                if item:
+                    list_text.append(item)
             return list_text
         if var_type == "list_number":
             var_list = value.split(',')

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/views.py
@@ -473,7 +473,7 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         lines = ["#"*(len(string)+8)]*4
         lines[2:2] = ["##" + " "*(len(string)+4) + "##"]*3
         lines[3] = lines[3][:4] + string + lines[3][-4:]
-        lines += [""]*2
+        lines += [""]*1
         return lines
         
     def format_class(variables, name, indent):
@@ -482,12 +482,12 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         standard_vars, advanced_vars = filter(lambda var: not var.is_advanced, variables), filter(lambda var: var.is_advanced, variables)
         
         def make_dict(variables, name): 
-            var_dict = {v.name: VariableUtils().wrap_in_type_syntax(v.value, v.type) for v in variables}
+            var_dict = {v.name: VariableUtils().convert_variable_to_type(v.value, v.type) for v in variables}
             return indent + name + " = " + str(var_dict)
         
-        lines += make_dict(standard_vars, "standard_vars")
-        lines += make_dict(advanced_vars, "advanced_vars")
-        lines += [""*3]
+        lines.append(make_dict(standard_vars, "standard_vars"))
+        lines.append(make_dict(advanced_vars, "advanced_vars"))
+        lines += [""]*3
         
         return lines
     
@@ -502,7 +502,7 @@ def preview_script(request, instrument, run_number=0, experiment_reference=0):
         lines = format_header("Reduction script - reduce.py") + lines
         
         # Figure out space/tabs
-        indent = "    " # Defaults to PEP-8 standard!
+        indent = "    " # Defaults to PEP 8 standard!
         if filter(lambda line: line.startswith("\t"), lines):
             indent = "\t"
         


### PR DESCRIPTION
Fixes #222 

Now the preview script button delivers a script with imports to `reduce_vars` removed, and a definition for a class that mocks it with the correct variables inserted. Ultimately not every script can be runnable on a user's desktop, because the reduction server is set up with a different environment (e.g., file paths for data files will be different). This should make it easy enough to fix those, though, since it provides the variables as they should be for the run.

Testing uncovered a few issues with the way variables were being updated, when variables had been added or removed from the script on disk; they've been fixed now.

To test:
* Go to an instrument page and hit 'preview script'. If the script imports `reduce_vars` somewhere (WISH's doesn't), these lines will be removed and a class consisting of the reduction variables inserted. It also prints some pretty headers for the two different files.