### PR TITLE
Check script file format

### DIFF
--- a/WebApp/ISIS/README.md
+++ b/WebApp/ISIS/README.md
@@ -33,7 +33,9 @@ Recommended Server OS: Red Hat Enterprise Linux (RHEL) 6 / 7
 
 ### Install Django
 1. `pip install django==1.7.1`
-2. `pip install pytz`
+
+### Install other Python dependencies
+1. `pip install pytz chardet`
 
 ### Installing application
 
@@ -228,7 +230,7 @@ Note: Git Bash is the recommended command line (after step 4). Any command line 
 8. Download and install http://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fpywin32%2Ffiles%2Fpywin32%2FBuild%2520219%2F&ts=1416304230&use_mirror=garr
 9. Download https://raw.github.com/pypa/pip/master/contrib/get-pip.py and run `python get-pip.py`
 10. Add `c:\python27\scripts` to the path environmental variable.
-11. `pip install django`
+11. `pip install django chardet`
 
 ### Configuring MySQL
 

--- a/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/reduction_variables/utils.py
@@ -1,4 +1,4 @@
-import logging, os, sys, re, json, cgi, imp, copy
+import logging, os, sys, re, json, cgi, imp, chardet, io
 sys.path.append(os.path.join("../", os.path.dirname(os.path.dirname(__file__))))
 os.environ["DJANGO_SETTINGS_MODULE"] = "autoreduce_webapp.settings"
 from autoreduce_webapp.settings import ACTIVEMQ, REDUCTION_DIRECTORY, FACILITY
@@ -367,9 +367,18 @@ class InstrumentVariablesUtils(object):
 
         
     def _load_script(self, path):
-        """ Load the relevant reduction script and return back the text of the script. If the script cannot be loaded, None is returned. """
+        """
+        First detect the file encoding using chardet.
+        Then load the relevant reduction script and return back the text of the script.
+        If the script cannot be loaded, None is returned.
+        """
         try:
-            f = open(path, 'r')
+            # Read raw bytes and determine encoding
+            f_raw = io.open(path, 'rb')
+            encoding = chardet.detect(f_raw.read(32))["encoding"]
+            
+            # Read the file in decoded; io is used for the encoding kwarg
+            f = io.open(path, 'r', encoding=encoding)
             script_text = f.read()
             return script_text
         except Exception as e:


### PR DESCRIPTION
Fixes #309 

This uses `chardet` to figure out the reduction script file encoding before reading it in, which is more robust than Python's standard methods. Hence, files with, e.g., `UTF-8-BOM` encoding will be recognised, and the marker char/s stripped.

To test:
* Run a reduction run with a script that's saved onto the disk in such a format (currently e.g. LET). Note that this won't work for re-runs that have already read their script in, unless you explicitly click `Reset to current script and values`.