### PR TITLE
Fix queue processor bug

### DIFF
--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
@@ -38,6 +38,7 @@ class Listener(object):
         self.updateChildProcessList()
         if not self.shouldProceed(data_dict): # wait while the run shouldn't proceed
             reactor.callLater(10, self.holdMessage, destination, data)
+            return
             
         if self.shouldCancel(data_dict):
             self.cancelRun(data_dict)

--- a/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
+++ b/ISISPostProcessRPM/rpmbuild/autoreduce-mq/usr/bin/queueProcessor.py
@@ -37,7 +37,7 @@ class Listener(object):
         
         self.updateChildProcessList()
         if not self.shouldProceed(data_dict): # wait while the run shouldn't proceed
-            reactor.callLater(10, holdMessage, self, destination, data)
+            reactor.callLater(10, self.holdMessage, destination, data)
             
         if self.shouldCancel(data_dict):
             self.cancelRun(data_dict)


### PR DESCRIPTION
Fixes #313 

The threaded model was fragile, and subject to race conditions, so I replaced the spinlocks with a single-threaded deferred callback model.

Because this was affecting service, this patch is already live on the production server.