### PR TITLE
EndOfRunMonitor ICAT Session Refresh Fix and Settings File Fix

### DIFF
--- a/scripts/EndOfRunMonitor/ICAT_Client.py
+++ b/scripts/EndOfRunMonitor/ICAT_Client.py
@@ -1,18 +1,24 @@
 import icat
 from settings import ICAT_SETTINGS
 
+"""
+This class provides a layer of abstraction from Python ICAT. Only allowing logging in and querying.
+"""
 
-class ICAT():
-    def get_client(self):
-        icat_client = icat.client.Client(ICAT_SETTINGS['URL'])
-        self.client_login(icat_client, ICAT_SETTINGS['AUTH'], ICAT_SETTINGS['USER'], ICAT_SETTINGS['PASSWORD'])
-        return icat_client
 
-    @staticmethod
-    def client_login(icat_client, auth, username, password):
-        return icat_client.login(auth, {'username': username, 'password': password})
+class ICAT:
 
-    @staticmethod
-    def execute_query(icat_client, query):
-        icat_client.refresh()
-        return icat_client.search(query)
+    def __init__(self):
+        self.client = icat.Client(ICAT_SETTINGS['URL'])
+        self.client_login()
+
+    def client_login(self):
+        self.client.login(ICAT_SETTINGS['AUTH'], {'username': ICAT_SETTINGS['USER'], 'password': ICAT_SETTINGS['PASSWORD']})
+
+    def execute_query(self, query):
+        try:
+            self.client.refresh()
+        except icat.exception.ICATSessionError:
+            # Session has most likely expired, try and log in again.
+            self.client_login()
+        return self.client.search(query)

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -23,7 +23,6 @@ QUERY = "SELECT facilityCycle.name FROM FacilityCycle facilityCycle, \
          datafile.datafileCreateTime BETWEEN facilityCycle.startDate AND \
          facilityCycle.endDate"
 
-TIME_CONSTANT = 1  # Time between file reads (in seconds)
 USE_FAKE_ARCHIVE = False  # If True will check fake_archive folder for the last_run.txt file and will not send data to DataReady queue"
 
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')

--- a/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
+++ b/scripts/EndOfRunMonitor/ISISendOfRunMonitor.py
@@ -24,7 +24,7 @@ QUERY = "SELECT facilityCycle.name FROM FacilityCycle facilityCycle, \
          facilityCycle.endDate"
 
 TIME_CONSTANT = 1  # Time between file reads (in seconds)
-DEBUG = False  # If True will check fake_archive folder for the last_run.txt file and will not send data to DataReady queue"
+USE_FAKE_ARCHIVE = False  # If True will check fake_archive folder for the last_run.txt file and will not send data to DataReady queue"
 
 logging.basicConfig(filename=LOG_FILE, level=logging.INFO, format='%(asctime)s %(message)s')
 observer = Observer()
@@ -53,7 +53,7 @@ class InstrumentMonitor(FileSystemEventHandler):
         self.client = client
         self.use_nexus = use_nexus
         self.instrumentName = instrument_name
-        if DEBUG:
+        if USE_FAKE_ARCHIVE:
             self.instrumentFolder = "fake_archive\\" + self.instrumentName
         else:
             self.instrumentFolder = INST_FOLDER % self.instrumentName
@@ -130,7 +130,7 @@ class InstrumentMonitor(FileSystemEventHandler):
         # Puts message together and sends it, along with logging.
         with self.lock:
             data_dict = self.build_dict(last_run_data)
-        if not DEBUG:
+        if not USE_FAKE_ARCHIVE:
             self.client.send('/queue/DataReady', json.dumps(data_dict), priority='9')
         logging.info("Data sent: " + str(data_dict))
 

--- a/scripts/EndOfRunMonitor/settings.py.template
+++ b/scripts/EndOfRunMonitor/settings.py.template
@@ -1,16 +1,16 @@
 # ICAT
 ICAT_SETTINGS = {
-    'AUTH': 'simple',
-    'URL': 'https://icatisis.esc.rl.ac.uk/ICATService/ICAT?wsdl',
-    'USER': 'autoreduce',
+    'AUTH': 'YOUR-ICAT-AUTH-TYPE',
+    'URL': 'YOUR-ICAT-WSDL-URL',
+    'USER': 'YOUR-ICAT-USERNAME',
     'PASSWORD': 'YOUR-PASSWORD'
 }
 # ActiveMQ
 ACTIVEMQ = {
-    "brokers": "reducequeue:61613",
+    "brokers": "YOUR-ACTIVEMQ-URL:61613",
     "amq_queues": ["/queue/ReductionPending"],
-    "amq_user": "autoreduce",
-    "amq_pwd": "YOUR-PASSWORD",
+    "amq_user": "YOUR-ACTIVEMQ-USERNAME",
+    "amq_pwd": "YOUR-ACTIVEMQ-PASSWORD",
     "postprocess_error": "/queue/ReductionError",
     "reduction_started": "/queue/ReductionStarted",
     "reduction_complete": "/queue/ReductionComplete",


### PR DESCRIPTION
This pull request: 

- Every time a change it made to last_run.txt the ICAT session is refreshed. However if the session has expired (after 2 hours of inactivity) and you try to refresh it an exception is thrown. This pull request fixes this by catching the exception and logging-in again, generating a new session id.
- Makes ICAT_Client.py into a proper class rather than it having static methods.
- Adds a `settings.py.template` file so passwords cannot accidentally be committed.