### PR TITLE
Increase WebApp speed

### DIFF
--- a/WebApp/ISIS/autoreduce_webapp/apache/apache_django_wsgi.conf
+++ b/WebApp/ISIS/autoreduce_webapp/apache/apache_django_wsgi.conf
@@ -1,5 +1,3 @@
-MaxRequestsPerChild 1
-
 # Location of the wsgi file and the WebApp base folder
 WSGIScriptAlias / C:/WebApp/autoreduce_webapp/autoreduce_webapp/wsgi.py
 WSGIPythonPath C:/WebApp/autoreduce_webapp

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py.template
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/settings.py.template
@@ -207,7 +207,7 @@ BASE_URL = 'http://reduce.isis.cclrc.ac.uk/'
 CERTIFICATE_LOCATION = 'C:\\certificates\\FITBAWEB1isiscclrcacuk.crt'
 
 # Constant vars
-
+SESSION_COOKIE_AGE = 3600  # The MAX length before user is logged out, 1 hour in seconds
 FACILITY = "ISIS"
 PRELOAD_RUNS_UNDER = 100  # If the index run list has fewer than this many runs to show the user, preload them all.
 CACHE_LIFETIME = 3600  # Objects in ICATCache live this many seconds when ICAT is available to update them.

--- a/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/view_utils.py
+++ b/WebApp/ISIS/autoreduce_webapp/autoreduce_webapp/view_utils.py
@@ -15,10 +15,12 @@ def has_valid_login(request):
     """
     Check that the user is correctly logged in and their session is still considered valid
     """
-    logger.info('Checking if user is authenticated')
+    logger.debug("Checking if user is authenticated")
     if DEVELOPMENT_MODE:
+        logger.debug("DEVELOPMENT_MODE True so allowing access")
         return True
-    if request.user.is_authenticated() and 'sessionid' in request.session and UOWSClient().check_session(request.session['sessionid']):
+    if request.user.is_authenticated() and 'sessionid' in request.session:
+        logger.debug("User is authenticated and has a sessionid from the UOWS")
         return True
     return False
 


### PR DESCRIPTION
This is a small commit that makes the webapp a lot faster.

It no longer will send a SOAP API call to the user office for every request that comes in, which sometimes took a second per request. The cookie timeout has been set to 1 hour so the django session will expire before the user office session. The only caveat being that if a user logs out of the user office system they remain logged into autoreduction.

It also removes the `MaxRequestsPerChild 1` that was in the Apache wsgi config, again this slowed down the WebApp a lot.

This can be seen working on http://reduce.isis.cclrc.ac.uk
